### PR TITLE
Add test coverage and use Problem Details in ratsd core API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 BIN := ratsd
 
 .PHONY: all
-all: generate build
+all: generate build test
 
 .PHONY: gen-certs
 gen-certs:
@@ -18,6 +18,10 @@ generate:
 .PHONY: build
 build:
 	go build -o $(BIN) -buildmode=pie ./cmd
+
+.PHONY: test
+test:
+	go test -v github.com/veraison/ratsd/api
 
 .PHONY: clean
 clean:

--- a/api/server.go
+++ b/api/server.go
@@ -1,3 +1,5 @@
+// Copyright 2025 Contributors to the Veraison project.
+// SPDX-License-Identifier: Apache-2.0
 package api
 
 import (

--- a/api/server.go
+++ b/api/server.go
@@ -15,6 +15,7 @@ import (
 // Defines missing consts in the API Spec
 const (
 	ApplicationvndVeraisonCharesJson string = "application/vnd.veraison.chares+json"
+	ExpectedAuth                     string = "Bearer my.jwt.token"
 )
 
 type Server struct {
@@ -36,6 +37,18 @@ func (s *Server) reportProblem(w http.ResponseWriter, prob *problems.DefaultProb
 
 func (s *Server) RatsdChares(w http.ResponseWriter, r *http.Request, param RatsdCharesParams) {
 	var requestData ChaResRequest
+
+	auth := r.Header.Get("Authorization")
+	if auth != ExpectedAuth {
+		p := &problems.DefaultProblem{
+			Type:   string(TagGithubCom2024VeraisonratsdErrorUnauthorized),
+			Title:  string(AccessUnauthorized),
+			Detail: "wrong or missing authorization header",
+			Status: http.StatusUnauthorized,
+		}
+		s.reportProblem(w, p)
+		return
+	}
 
 	// Check if content type matches the expectation
 	ct := r.Header.Get("Content-Type")

--- a/api/server.go
+++ b/api/server.go
@@ -52,11 +52,15 @@ func (s *Server) RatsdChares(w http.ResponseWriter, r *http.Request, param Ratsd
 	}
 
 	respCt := fmt.Sprintf(`application/eat+jwt; eat_profile=%q`, TagGithubCom2024Veraisonratsd)
-	if *(param.Accept) != respCt {
-		errMsg := fmt.Sprintf("wrong accept type, expect %s (got %s)", respCt, *(param.Accept))
-		p := problems.NewDetailedProblem(http.StatusNotAcceptable, errMsg)
-		s.reportProblem(w, p)
-		return
+	if param.Accept != nil {
+		s.logger.Info("request media type: ", *(param.Accept))
+		if *(param.Accept) != respCt && *(param.Accept) != "*/*" {
+			errMsg := fmt.Sprintf(
+				"wrong accept type, expect %s (got %s)", respCt, *(param.Accept))
+			p := problems.NewDetailedProblem(http.StatusNotAcceptable, errMsg)
+			s.reportProblem(w, p)
+			return
+		}
 	}
 
 	payload, _ := io.ReadAll(r.Body)
@@ -74,7 +78,6 @@ func (s *Server) RatsdChares(w http.ResponseWriter, r *http.Request, param Ratsd
 	}
 
 	s.logger.Info("request nonce: ", requestData.Nonce)
-	s.logger.Info("request media type: ", *(param.Accept))
 	w.Header().Set("Content-Type", respCt)
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte("hello from ratsd!"))

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -1,0 +1,124 @@
+// Copyright 2025 Contributors to the Veraison project.
+// SPDX-License-Identifier: Apache-2.0
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/moogar0880/problems"
+	"github.com/stretchr/testify/assert"
+	"github.com/veraison/services/log"
+)
+
+const (
+	jsonType = "application/json"
+)
+
+func TestRatsdChares_wrong_content_type(t *testing.T) {
+	expectedCode := http.StatusBadRequest
+	expectedType := problems.ProblemMediaType
+	expectedBody := &problems.DefaultProblem{
+		Type:   string(TagGithubCom2024VeraisonratsdErrorInvalidrequest),
+		Title:  string(InvalidRequest),
+		Status: http.StatusBadRequest,
+		Detail: fmt.Sprintf("wrong content type, expect %s (got %s)", ApplicationvndVeraisonCharesJson, jsonType),
+	}
+
+	var params RatsdCharesParams
+	logger := log.Named("test")
+	s := &Server{logger: logger}
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest(http.MethodPost, "/ratsd/chares", http.NoBody)
+	r.Header.Add("Content-Type", jsonType)
+	s.RatsdChares(w, r, params)
+
+	var body problems.DefaultProblem
+	_ = json.Unmarshal(w.Body.Bytes(), &body)
+
+	assert.Equal(t, expectedCode, w.Code)
+	assert.Equal(t, expectedType, w.Result().Header.Get("Content-Type"))
+	assert.Equal(t, expectedBody, &body)
+}
+
+func TestRatsdChares_wrong_accept_type(t *testing.T) {
+	var params RatsdCharesParams
+
+	param := jsonType
+	params.Accept = &param
+	logger := log.Named("test")
+	s := &Server{logger: logger}
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest(http.MethodPost, "/ratsd/chares", http.NoBody)
+	r.Header.Add("Content-Type", ApplicationvndVeraisonCharesJson)
+	s.RatsdChares(w, r, params)
+
+	respCt := fmt.Sprintf(`application/eat+jwt; eat_profile=%q`, TagGithubCom2024Veraisonratsd)
+	expectedCode := http.StatusNotAcceptable
+	expectedType := problems.ProblemMediaType
+	expectedDetail := fmt.Sprintf("wrong accept type, expect %s (got %s)", respCt, *(params.Accept))
+	expectedBody := problems.NewDetailedProblem(http.StatusNotAcceptable, expectedDetail)
+
+	var body problems.DefaultProblem
+	_ = json.Unmarshal(w.Body.Bytes(), &body)
+
+	assert.Equal(t, expectedCode, w.Code)
+	assert.Equal(t, expectedType, w.Result().Header.Get("Content-Type"))
+	assert.Equal(t, expectedBody, &body)
+}
+
+func TestRatsdChares_missing_nonce(t *testing.T) {
+	var params RatsdCharesParams
+
+	param := fmt.Sprintf(`application/eat+jwt; eat_profile=%q`, TagGithubCom2024Veraisonratsd)
+	params.Accept = &param
+	logger := log.Named("test")
+	s := &Server{logger: logger}
+	w := httptest.NewRecorder()
+	rb := strings.NewReader("{\"noncee\": \"MIDBNH28iioisjPy\"}")
+	r, _ := http.NewRequest(http.MethodPost, "/ratsd/chares", rb)
+	r.Header.Add("Content-Type", ApplicationvndVeraisonCharesJson)
+	s.RatsdChares(w, r, params)
+
+	expectedCode := http.StatusBadRequest
+	expectedType := problems.ProblemMediaType
+	expectedBody := &problems.DefaultProblem{
+		Type:   string(TagGithubCom2024VeraisonratsdErrorInvalidrequest),
+		Title:  string(InvalidRequest),
+		Status: http.StatusBadRequest,
+		Detail: "fail to retrieve nonce from the request",
+	}
+
+	var body problems.DefaultProblem
+	_ = json.Unmarshal(w.Body.Bytes(), &body)
+
+	assert.Equal(t, expectedCode, w.Code)
+	assert.Equal(t, expectedType, w.Result().Header.Get("Content-Type"))
+	assert.Equal(t, expectedBody, &body)
+}
+
+func TestRatsdChares_valid_request(t *testing.T) {
+	var params RatsdCharesParams
+
+	param := fmt.Sprintf(`application/eat+jwt; eat_profile=%q`, TagGithubCom2024Veraisonratsd)
+	params.Accept = &param
+	logger := log.Named("test")
+	s := &Server{logger: logger}
+	w := httptest.NewRecorder()
+	rb := strings.NewReader("{\"nonce\": \"MIDBNH28iioisjPy\"}")
+	r, _ := http.NewRequest(http.MethodPost, "/ratsd/chares", rb)
+	r.Header.Add("Content-Type", ApplicationvndVeraisonCharesJson)
+	s.RatsdChares(w, r, params)
+
+	expectedCode := http.StatusOK
+	expectedType := param
+	expectedBody := "hello from ratsd!"
+
+	assert.Equal(t, expectedCode, w.Code)
+	assert.Equal(t, expectedType, w.Result().Header.Get("Content-Type"))
+	assert.Equal(t, expectedBody, w.Body.String())
+}

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -19,6 +19,31 @@ const (
 	jsonType = "application/json"
 )
 
+func TestRatsdChares_missing_auth_header(t *testing.T) {
+	expectedCode := http.StatusUnauthorized
+	expectedType := problems.ProblemMediaType
+	expectedBody := &problems.DefaultProblem{
+		Type:   string(TagGithubCom2024VeraisonratsdErrorUnauthorized),
+		Title:  string(AccessUnauthorized),
+		Status: http.StatusUnauthorized,
+		Detail: "wrong or missing authorization header",
+	}
+
+	var params RatsdCharesParams
+	logger := log.Named("test")
+	s := &Server{logger: logger}
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest(http.MethodPost, "/ratsd/chares", http.NoBody)
+	s.RatsdChares(w, r, params)
+
+	var body problems.DefaultProblem
+	_ = json.Unmarshal(w.Body.Bytes(), &body)
+
+	assert.Equal(t, expectedCode, w.Code)
+	assert.Equal(t, expectedType, w.Result().Header.Get("Content-Type"))
+	assert.Equal(t, expectedBody, &body)
+}
+
 func TestRatsdChares_wrong_content_type(t *testing.T) {
 	expectedCode := http.StatusBadRequest
 	expectedType := problems.ProblemMediaType
@@ -34,6 +59,7 @@ func TestRatsdChares_wrong_content_type(t *testing.T) {
 	s := &Server{logger: logger}
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodPost, "/ratsd/chares", http.NoBody)
+	r.Header.Add("Authorization", ExpectedAuth)
 	r.Header.Add("Content-Type", jsonType)
 	s.RatsdChares(w, r, params)
 
@@ -54,6 +80,7 @@ func TestRatsdChares_wrong_accept_type(t *testing.T) {
 	s := &Server{logger: logger}
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodPost, "/ratsd/chares", http.NoBody)
+	r.Header.Add("Authorization", ExpectedAuth)
 	r.Header.Add("Content-Type", ApplicationvndVeraisonCharesJson)
 	s.RatsdChares(w, r, params)
 
@@ -81,6 +108,7 @@ func TestRatsdChares_missing_nonce(t *testing.T) {
 	w := httptest.NewRecorder()
 	rb := strings.NewReader("{\"noncee\": \"MIDBNH28iioisjPy\"}")
 	r, _ := http.NewRequest(http.MethodPost, "/ratsd/chares", rb)
+	r.Header.Add("Authorization", ExpectedAuth)
 	r.Header.Add("Content-Type", ApplicationvndVeraisonCharesJson)
 	s.RatsdChares(w, r, params)
 
@@ -111,6 +139,7 @@ func TestRatsdChares_valid_request(t *testing.T) {
 	w := httptest.NewRecorder()
 	rb := strings.NewReader("{\"nonce\": \"MIDBNH28iioisjPy\"}")
 	r, _ := http.NewRequest(http.MethodPost, "/ratsd/chares", rb)
+	r.Header.Add("Authorization", ExpectedAuth)
 	r.Header.Add("Content-Type", ApplicationvndVeraisonCharesJson)
 	s.RatsdChares(w, r, params)
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,3 +1,5 @@
+// Copyright 2025 Contributors to the Veraison project.
+// SPDX-License-Identifier: Apache-2.0
 package main
 
 import (

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/getkin/kin-openapi v0.128.0
 	github.com/moogar0880/problems v0.1.1
 	github.com/oapi-codegen/runtime v1.1.1
+	github.com/stretchr/testify v1.9.0
 	github.com/veraison/services v0.0.2501
 	go.uber.org/zap v1.23.0
 	google.golang.org/grpc v1.64.0
@@ -18,6 +19,7 @@ require (
 	github.com/bytedance/sonic v1.11.3 // indirect
 	github.com/chenzhuoyu/base64x v0.0.0-20230717121745-296ad89f973d // indirect
 	github.com/chenzhuoyu/iasm v0.9.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dprotaso/go-yit v0.0.0-20220510233725-9ba8df137936 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/fsnotify/fsnotify v1.5.4 // indirect
@@ -51,6 +53,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.2.0 // indirect
 	github.com/perimeterx/marshmallow v1.1.5 // indirect
 	github.com/petar-dambovaliev/aho-corasick v0.0.0-20211021192214-5ab2d9280aa9 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/speakeasy-api/openapi-overlay v0.9.0 // indirect
 	github.com/spf13/afero v1.9.2 // indirect
 	github.com/spf13/cast v1.5.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.22.7
 
 require (
 	github.com/getkin/kin-openapi v0.128.0
+	github.com/moogar0880/problems v0.1.1
 	github.com/oapi-codegen/runtime v1.1.1
 	github.com/veraison/services v0.0.2501
 	go.uber.org/zap v1.23.0
@@ -45,7 +46,6 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
-	github.com/moogar0880/problems v0.1.1 // indirect
 	github.com/oapi-codegen/oapi-codegen/v2 v2.4.1 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.0 // indirect


### PR DESCRIPTION
Fix #22 with RFC 7807 to align with how Veraison/Services handles HTTP client errors. 