### PR TITLE
Add real HTTP authentication backend

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -15,7 +15,6 @@ import (
 // Defines missing consts in the API Spec
 const (
 	ApplicationvndVeraisonCharesJson string = "application/vnd.veraison.chares+json"
-	ExpectedAuth                     string = "Bearer my.jwt.token"
 )
 
 type Server struct {
@@ -37,18 +36,6 @@ func (s *Server) reportProblem(w http.ResponseWriter, prob *problems.DefaultProb
 
 func (s *Server) RatsdChares(w http.ResponseWriter, r *http.Request, param RatsdCharesParams) {
 	var requestData ChaResRequest
-
-	auth := r.Header.Get("Authorization")
-	if auth != ExpectedAuth {
-		p := &problems.DefaultProblem{
-			Type:   string(TagGithubCom2024VeraisonratsdErrorUnauthorized),
-			Title:  string(AccessUnauthorized),
-			Detail: "wrong or missing authorization header",
-			Status: http.StatusUnauthorized,
-		}
-		s.reportProblem(w, p)
-		return
-	}
 
 	// Check if content type matches the expectation
 	ct := r.Header.Get("Content-Type")

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -19,31 +19,6 @@ const (
 	jsonType = "application/json"
 )
 
-func TestRatsdChares_missing_auth_header(t *testing.T) {
-	expectedCode := http.StatusUnauthorized
-	expectedType := problems.ProblemMediaType
-	expectedBody := &problems.DefaultProblem{
-		Type:   string(TagGithubCom2024VeraisonratsdErrorUnauthorized),
-		Title:  string(AccessUnauthorized),
-		Status: http.StatusUnauthorized,
-		Detail: "wrong or missing authorization header",
-	}
-
-	var params RatsdCharesParams
-	logger := log.Named("test")
-	s := &Server{logger: logger}
-	w := httptest.NewRecorder()
-	r, _ := http.NewRequest(http.MethodPost, "/ratsd/chares", http.NoBody)
-	s.RatsdChares(w, r, params)
-
-	var body problems.DefaultProblem
-	_ = json.Unmarshal(w.Body.Bytes(), &body)
-
-	assert.Equal(t, expectedCode, w.Code)
-	assert.Equal(t, expectedType, w.Result().Header.Get("Content-Type"))
-	assert.Equal(t, expectedBody, &body)
-}
-
 func TestRatsdChares_wrong_content_type(t *testing.T) {
 	expectedCode := http.StatusBadRequest
 	expectedType := problems.ProblemMediaType
@@ -59,7 +34,6 @@ func TestRatsdChares_wrong_content_type(t *testing.T) {
 	s := &Server{logger: logger}
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodPost, "/ratsd/chares", http.NoBody)
-	r.Header.Add("Authorization", ExpectedAuth)
 	r.Header.Add("Content-Type", jsonType)
 	s.RatsdChares(w, r, params)
 
@@ -80,7 +54,6 @@ func TestRatsdChares_wrong_accept_type(t *testing.T) {
 	s := &Server{logger: logger}
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodPost, "/ratsd/chares", http.NoBody)
-	r.Header.Add("Authorization", ExpectedAuth)
 	r.Header.Add("Content-Type", ApplicationvndVeraisonCharesJson)
 	s.RatsdChares(w, r, params)
 
@@ -108,7 +81,6 @@ func TestRatsdChares_missing_nonce(t *testing.T) {
 	w := httptest.NewRecorder()
 	rb := strings.NewReader("{\"noncee\": \"MIDBNH28iioisjPy\"}")
 	r, _ := http.NewRequest(http.MethodPost, "/ratsd/chares", rb)
-	r.Header.Add("Authorization", ExpectedAuth)
 	r.Header.Add("Content-Type", ApplicationvndVeraisonCharesJson)
 	s.RatsdChares(w, r, params)
 
@@ -139,7 +111,6 @@ func TestRatsdChares_valid_request(t *testing.T) {
 	w := httptest.NewRecorder()
 	rb := strings.NewReader("{\"nonce\": \"MIDBNH28iioisjPy\"}")
 	r, _ := http.NewRequest(http.MethodPost, "/ratsd/chares", rb)
-	r.Header.Add("Authorization", ExpectedAuth)
 	r.Header.Add("Content-Type", ApplicationvndVeraisonCharesJson)
 	s.RatsdChares(w, r, params)
 

--- a/auth/authorizer.go
+++ b/auth/authorizer.go
@@ -1,0 +1,45 @@
+// Copyright 2025 Contributors to the Veraison project.
+// SPDX-License-Identifier: Apache-2.0
+
+package auth
+
+import (
+	"fmt"
+
+	"github.com/spf13/viper"
+	"github.com/veraison/services/config"
+	"go.uber.org/zap"
+)
+
+type cfg struct {
+	Backend        string                 `mapstructure:"backend,omitempty"`
+	BackendConfigs map[string]interface{} `mapstructure:",remain"`
+}
+
+func NewAuthorizer(v *viper.Viper, logger *zap.SugaredLogger) (IAuthorizer, error) {
+	cfg := cfg{
+		Backend: "passthrough",
+	}
+
+	loader := config.NewLoader(&cfg)
+	if err := loader.LoadFromViper(v); err != nil {
+		return nil, err
+	}
+
+	var a IAuthorizer
+
+	switch cfg.Backend {
+	case "none", "passthrough":
+		a = &PassthroughAuthorizer{}
+	case "basic":
+		a = &BasicAuthorizer{}
+	default:
+		return nil, fmt.Errorf("backend %q is not supported", cfg.Backend)
+	}
+
+	if err := a.Init(v, logger); err != nil {
+		return nil, err
+	}
+
+	return a, nil
+}

--- a/auth/basic.go
+++ b/auth/basic.go
@@ -1,0 +1,113 @@
+// Copyright 2025 Contributors to the Veraison project.
+// SPDX-License-Identifier: Apache-2.0
+
+package auth
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/spf13/viper"
+	"github.com/veraison/services/log"
+	"go.uber.org/zap"
+	"golang.org/x/crypto/bcrypt"
+)
+
+type basicAuthUser struct {
+	PasswordHash string `mapstructure:"password"`
+}
+
+func newBasicAuthUser(m map[string]interface{}) (*basicAuthUser, error) {
+	var newUser basicAuthUser
+
+	passRaw, ok := m["password"]
+	if !ok {
+		return nil, errors.New("password not set")
+	}
+
+	switch t := passRaw.(type) {
+	case string:
+		newUser.PasswordHash = t
+	default:
+		return nil, fmt.Errorf("invalid password: expected string found %T", t)
+	}
+
+	return &newUser, nil
+}
+
+type BasicAuthorizer struct {
+	logger *zap.SugaredLogger
+	users  map[string]*basicAuthUser
+}
+
+func (o *BasicAuthorizer) Init(v *viper.Viper, logger *zap.SugaredLogger) error {
+	if logger == nil {
+		return errors.New("nil logger")
+	}
+	o.logger = logger
+
+	o.users = make(map[string]*basicAuthUser)
+	if rawUsers := v.GetStringMap("users"); rawUsers != nil {
+		for name, rawUser := range rawUsers {
+			switch t := rawUser.(type) {
+			case map[string]interface{}:
+				newUser, err := newBasicAuthUser(t)
+				if err != nil {
+					return fmt.Errorf("invalid user %q: %w", name, err)
+
+				}
+				o.logger.Debugw("registered user",
+					"user", name,
+					"hashed password", newUser.PasswordHash,
+				)
+				o.users[name] = newUser
+			default:
+				return fmt.Errorf(
+					"invalid user %q: expected map[string]interface{}, got %T",
+					name, t,
+				)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (o *BasicAuthorizer) Close() error {
+	return nil
+}
+
+func (o *BasicAuthorizer) GetMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			o.logger.Debugw("auth basic", "path", r.URL.Path)
+
+			userName, password, hasAuth := r.BasicAuth()
+			if !hasAuth {
+				w.Header().Set("WWW-Authenticate", "Basic realm=veraison")
+				ReportProblem(o.logger, w, "no Basic Authorizaiton given")
+				return
+			}
+
+			userInfo, ok := o.users[userName]
+			if !ok {
+				w.Header().Set("WWW-Authenticate", "Basic realm=veraison")
+				ReportProblem(o.logger, w, fmt.Sprintf("no such user: %s", userName))
+				return
+			}
+
+			if err := bcrypt.CompareHashAndPassword(
+				[]byte(userInfo.PasswordHash),
+				[]byte(password),
+			); err != nil {
+				o.logger.Debugf("password check failed: %v", err)
+				w.Header().Set("WWW-Authenticate", "Basic realm=veraison")
+				ReportProblem(o.logger, w, "wrong username or password")
+				return
+			}
+
+			log.Debugw("user authenticated", "user", userName)
+			next.ServeHTTP(w, r)
+		})
+}

--- a/auth/iauthorizer.go
+++ b/auth/iauthorizer.go
@@ -1,0 +1,26 @@
+// Copyright 2025 Contributors to the Veraison project.
+// SPDX-License-Identifier: Apache-2.0
+
+package auth
+
+import (
+	"net/http"
+
+	"github.com/spf13/viper"
+	"go.uber.org/zap"
+)
+
+// IAuthorizer defines the interface that must be implemented by the veraison
+// auth backends.
+type IAuthorizer interface {
+	// Init initializes the backend based on the configuration inside the
+	// provided Viper object and using the provided logger.
+	Init(v *viper.Viper, logger *zap.SugaredLogger) error
+
+	// Close terminates the backend. The exact nature of this method is
+	// backend-specific.
+	Close() error
+
+	// GetMiddleware returns an http.Handler that performs authorization
+	GetMiddleware(http.Handler) http.Handler
+}

--- a/auth/passthrough.go
+++ b/auth/passthrough.go
@@ -1,0 +1,39 @@
+// Copyright 2025 Contributors to the Veraison project.
+// SPDX-License-Identifier: Apache-2.0
+package auth
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/spf13/viper"
+	"go.uber.org/zap"
+)
+
+type PassthroughAuthorizer struct {
+	logger *zap.SugaredLogger
+}
+
+func NewPassthroughAuthorizer(logger *zap.SugaredLogger) IAuthorizer {
+	return &PassthroughAuthorizer{logger: logger}
+}
+
+func (o *PassthroughAuthorizer) Init(v *viper.Viper, logger *zap.SugaredLogger) error {
+	if logger == nil {
+		return errors.New("nil logger")
+	}
+	o.logger = logger
+	return nil
+}
+
+func (o *PassthroughAuthorizer) Close() error {
+	return nil
+}
+
+func (o *PassthroughAuthorizer) GetMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			o.logger.Debugw("passthrough", "path", r.URL.Path)
+			next.ServeHTTP(w, r)
+		})
+}

--- a/auth/problem.go
+++ b/auth/problem.go
@@ -1,0 +1,25 @@
+// Copyright 2024 Contributors to the Veraison project.
+// SPDX-License-Identifier: Apache-2.0
+package auth
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/moogar0880/problems"
+	"github.com/veraison/ratsd/api"
+	"go.uber.org/zap"
+)
+
+func ReportProblem(logger *zap.SugaredLogger, w http.ResponseWriter, detail string) {
+	p := &problems.DefaultProblem{
+		Type:   string(api.TagGithubCom2024VeraisonratsdErrorUnauthorized),
+		Title:  string(api.AccessUnauthorized),
+		Detail: detail,
+		Status: http.StatusUnauthorized,
+	}
+
+	w.Header().Set("Content-Type", problems.ProblemMediaType)
+	w.WriteHeader(p.ProblemStatus())
+	json.NewEncoder(w).Encode(p)
+}


### PR DESCRIPTION
Add real HTTP authentication backend based on [services/auth](https://github.com/veraison/services/tree/main/auth), and relocate the Authentication check to a middleware. This allows users to pick the authentication scheme (`none` or `basic`, as defined in [RFC7617](https://datatracker.ietf.org/doc/html/rfc7617)) for ratsd. 