### PR TITLE
Revamp the TSM attester implementation

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -145,7 +145,7 @@ func (s *Server) RatsdChares(w http.ResponseWriter, r *http.Request, param Ratsd
 				pn, formatOut.Status.Error)
 			p := problems.NewDetailedProblem(http.StatusInternalServerError, errMsg)
 			s.reportProblem(w, p)
-			continue
+			return
 		}
 
 		params, hasOption := options[pn]

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -98,7 +98,7 @@ func TestRatsdChares_invalid_body(t *testing.T) {
 	tests := []struct{ name, body, msg string }{
 		{"missing nonce", `{"noncee": "MIDBNH28iioisjPy"}`,
 			"fail to retrieve nonce from the request"},
-		{"invlid attester selecton",
+		{"invalid attester selecton",
 			fmt.Sprintf(`{"nonce": "%s",
 		"attester-selection": "attester-slection"}`, validNonce),
 			"failed to parse attester selection: json: cannot unmarshal string into" +

--- a/attesters/tsm/tsm.go
+++ b/attesters/tsm/tsm.go
@@ -80,15 +80,15 @@ func (t *TSMPlugin) GetEvidence(in *compositor.EvidenceIn) *compositor.EvidenceO
 
 	for _, format := range supportedFormats {
 		if in.ContentType == format.ContentType {
+			req := &report.Request{
+				InBlob:     in.Nonce,
+				GetAuxBlob: true,
+			}
+
 			client, err := linuxtsm.MakeClient()
 			if err != nil {
 				errMsg := fmt.Errorf("failed to create config TSM client: %v", err)
 				return getEvidenceError(errMsg)
-			}
-
-			req := &report.Request{
-				InBlob:     in.Nonce,
-				GetAuxBlob: true,
 			}
 
 			resp, err := report.Get(client, req)

--- a/attesters/tsm/tsm.go
+++ b/attesters/tsm/tsm.go
@@ -125,15 +125,18 @@ func (t *TSMPlugin) GetEvidence(in *compositor.EvidenceIn) *compositor.EvidenceO
 			}
 
 			var encodeOp func() ([]byte, error)
+			encodeAs := "JSON"
+
 			if in.ContentType == ApplicationvndVeraisonConfigfsTsmCbor {
 				encodeOp = out.ToCBOR
+				encodeAs = "CBOR"
 			} else {
 				encodeOp = out.ToJSON
 			}
 
 			outEncoded, err := encodeOp()
 			if err != nil {
-				errMsg := fmt.Errorf("failed to JSON encode mock TSM report: %v", err)
+				errMsg := fmt.Errorf("failed to encode TSM report as %s: %v", encodeAs, err)
 				return getEvidenceError(errMsg)
 			}
 

--- a/attesters/tsm/tsm_test.go
+++ b/attesters/tsm/tsm_test.go
@@ -11,6 +11,10 @@ import (
 	"github.com/veraison/ratsd/proto/compositor"
 )
 
+var (
+	p = &TSMPlugin{}
+)
+
 func Test_getEvidenceError(t *testing.T) {
 	e := fmt.Errorf("sample error")
 
@@ -24,8 +28,6 @@ func Test_getEvidenceError(t *testing.T) {
 }
 
 func Test_GetSubAttesterID(t *testing.T) {
-	p := &TSMPlugin{}
-
 	expected := &compositor.SubAttesterIDOut{
 		SubAttesterID: sid,
 		Status:        statusSucceeded,
@@ -35,7 +37,6 @@ func Test_GetSubAttesterID(t *testing.T) {
 }
 
 func Test_GetSupportedFormats(t *testing.T) {
-	p := &TSMPlugin{}
 	var expected *compositor.SupportedFormatsOut
 
 	if _, err := linuxtsm.MakeClient(); err != nil {

--- a/attesters/tsm/tsm_test.go
+++ b/attesters/tsm/tsm_test.go
@@ -60,6 +60,42 @@ func Test_GetSupportedFormats(t *testing.T) {
 	assert.Equal(t, expected, p.GetSupportedFormats())
 }
 
+func Test_GetEvidence_wrong_nonce_size(t *testing.T) {
+	inblob := []byte("abcdefghijklmnopqrstuvwxyz123456")
+	in := &compositor.EvidenceIn{
+		ContentType: ApplicationvndVeraisonConfigfsTsmJson,
+		Nonce:       inblob,
+	}
+
+	errMsg := fmt.Sprintf(
+		"nonce size of the TSM attester should be %d, got %d", tsmNonceSize, len(inblob))
+	expected := &compositor.EvidenceOut{
+		Status: &compositor.Status{
+			Result: false,
+			Error:  errMsg,
+		},
+	}
+
+	assert.Equal(t, expected, p.GetEvidence(in))
+}
+
+func Test_GetEvidence_invalid_format(t *testing.T) {
+	inblob := []byte(validNonceStr)
+	in := &compositor.EvidenceIn{
+		ContentType: string("mediaType"),
+		Nonce:       inblob,
+	}
+
+	expected := &compositor.EvidenceOut{
+		Status: &compositor.Status{
+			Result: false,
+			Error:  "no supported format in tsm plugin matches the requested format",
+		},
+	}
+
+	assert.Equal(t, expected, p.GetEvidence(in))
+}
+
 func TestGetEvidence_With_Invalid_Options(t *testing.T) {
 	tests := []struct{ name, params, msg string }{
 		{"privilege level not integer", `{"privilege_level": "invalid"}`,

--- a/plugin/goplugin_context.go
+++ b/plugin/goplugin_context.go
@@ -80,8 +80,8 @@ func createPluginContext(
 	}
 
 	blob := handle.GetSubAttesterID()
-	if blob.Status.Result {
-		return nil, fmt.Errorf("failed to retrieve subattestr ID from %s", path)
+	if !blob.Status.Result {
+		return nil, fmt.Errorf("failed to retrieve subattester ID from %s", path)
 	}
 
 	return &PluginContext{


### PR DESCRIPTION
The PR brings in the following improvements to the TSM attester

- Use tokens.TSMReport instead of a Golang map
- Add support to specify privilege level in attester-specific options
- Add test coverage for `GetEvidence()`