### PR TITLE
docs: add CDDL definition of the RATSD tokens

### DIFF
--- a/docs/ratsd-token-example.diag
+++ b/docs/ratsd-token-example.diag
@@ -1,0 +1,29 @@
+18([
+  / phdr / <<{
+    / x5chain / 33: h'FF'
+  } >>,
+  / uhdr / {},
+  <<{
+      "__cmwc_t": "tag:github.com,2025:veraison/ratsd/cmw/v2",
+
+      "__ratsd": [
+        "application/eat-ucs+cbor; eat_profile=\"tag:github.com,2026:veraison/ratsd/v2\"",
+        << 
+          601({
+            / eat_profile / 265: "tag:github.com,2026:veraison/ratsd/v2",
+            / eat_nonce /   10: h'375FB85D414BF45F43DE0412EA15697D2E9473'
+          })
+        >>],
+
+      "configfs-tsm": [
+        "application/vnd.veraison.tsm-report+cbor",
+        << 
+          {
+            "outblob": h'FF',
+            "provider": "some TEE"
+          }
+        >>
+      ]
+  }>>,
+  / signature / h'FF'
+])

--- a/docs/ratsd-token.cddl
+++ b/docs/ratsd-token.cddl
@@ -36,7 +36,7 @@ uhdrs = {}
 ;;;;;;;;;;;;;;;;;;
 
 ratsd-token-legacy = {
-  "eat_profile": "tag:github.com,2024:veraison/ratsd/v2"
+  "eat_profile": "tag:github.com,2024:veraison/ratsd"
   "eat_nonce": text .size (8..88)
   "cmw": text ; .b64u ratsd-collection
 }

--- a/docs/ratsd-token.cddl
+++ b/docs/ratsd-token.cddl
@@ -1,13 +1,31 @@
 start = eat.CBOR-ONLY<ratsd-token> /
         eat.JSON-ONLY<ratsd-token-legacy>
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; RATSD CMW collection ;;
-;;;;;;;;;;;;;;;;;;;;;;;;;;
+RATSD-CLAIMS-PROFILE = "tag:github.com,2026:veraison/ratsd/v2"
+RATSD-CLAIMS-MEDIA-TYPE = ("application/eat-ucs+cbor; eat_profile=\"" .cat RATSD-CLAIMS-PROFILE) .cat "\""
+RATSD-CMWCT = "tag:github.com,2025:veraison/ratsd/cmw/v2"
+RATSD-CMWCT-LEGACY = "tag:github.com,2025:veraison/ratsd/cmw"
+
+;;;;;;;;;;;;;;;;;;;;
+;; CMW collection ;;
+;;;;;;;;;;;;;;;;;;;;
 
 ratsd-collection = {
-  "__cmwc_t" => "tag:github.com,2025:veraison/ratsd/cmw"
-  + text => eat.JC<cmw.json-record, cmw.cbor-record>
+  "__cmwc_t" => RATSD-CMWCT
+  "__ratsd" => [
+    RATSD-CLAIMS-MEDIA-TYPE,
+    bytes .cbor ratsd-claims
+  ]
+  + text => cmw.cbor-record
+}
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; legacy CMW collection ;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+ratsd-collection-legacy = {
+  "__cmwc_t" => RATSD-CMWCT-LEGACY
+  + text => cmw.json-record
 }
 
 ;;;;;;;;;;;;;;
@@ -21,12 +39,13 @@ ratsd-token = #6.18([
   signature: bytes
 ])
 
+ratsd-claims = #6.601({
+  &(eat_profile: 265) => RATSD-CLAIMS-PROFILE
+  &(eat_nonce: 10) => bytes .size (8..64)
+})
+
 phdrs = {
-  15: {                           ; CWT Claims (RFC 9597)
-    10: bytes .size (8..64)         ; EAT nonce (RFC 9711)
-    265: "tag:github.com,2026:veraison/ratsd/v2"  ; EAT profile (RFC 9711)
-  }
-  33: bytes / [ 2*certs: bytes ]  ; x5chain (RFC 9360)
+  ? &(x5chain: 33) => bytes / [ 2*certs: bytes ]
 }
 
 uhdrs = {}
@@ -38,7 +57,7 @@ uhdrs = {}
 ratsd-token-legacy = {
   "eat_profile": "tag:github.com,2024:veraison/ratsd"
   "eat_nonce": text .size (8..88)
-  "cmw": text ; .b64u ratsd-collection
+  "cmw": text ; .b64u ratsd-collection-legacy
 }
 
 ;;;;;;;;;;;;;;;;

--- a/docs/ratsd-token.cddl
+++ b/docs/ratsd-token.cddl
@@ -1,0 +1,84 @@
+start = eat.CBOR-ONLY<ratsd-token> /
+        eat.JSON-ONLY<ratsd-token-legacy>
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; RATSD CMW collection ;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+ratsd-collection = {
+  "__cmwc_t" => "tag:github.com,2025:veraison/ratsd/cmw"
+  + text => eat.JC<cmw.json-record, cmw.cbor-record>
+}
+
+;;;;;;;;;;;;;;
+;; token v2 ;;
+;;;;;;;;;;;;;;
+
+ratsd-token = #6.18([
+  protected: bytes .cbor phdrs
+  unprotected: uhdrs
+  payload: bytes .cbor ratsd-collection
+  signature: bytes
+])
+
+phdrs = {
+  15: {                           ; CWT Claims (RFC 9597)
+    10: bytes .size (8..64)         ; EAT nonce (RFC 9711)
+    265: "tag:github.com,2026:veraison/ratsd/v2"  ; EAT profile (RFC 9711)
+  }
+  33: bytes / [ 2*certs: bytes ]  ; x5chain (RFC 9360)
+}
+
+uhdrs = {}
+
+;;;;;;;;;;;;;;;;;;
+;; legacy token ;;
+;;;;;;;;;;;;;;;;;;
+
+ratsd-token-legacy = {
+  "eat_profile": "tag:github.com,2024:veraison/ratsd/v2"
+  "eat_nonce": text .size (8..88)
+  "cmw": text ; .b64u ratsd-collection
+}
+
+;;;;;;;;;;;;;;;;
+;; CMW import ;;
+;;;;;;;;;;;;;;;;
+
+;# import cmw
+
+cmw.cbor-record = [
+  type: cmw.coap-content-format-type / cmw.media-type
+  value: bytes
+  ? ind: uint .bits cmw.cm-type
+]
+
+cmw.media-type = text ; simplified
+
+cmw.coap-content-format-type = uint .size 2
+
+cmw.cm-type = &(
+  reference-values: 0
+  endorsements: 1
+  evidence: 2
+  attestation-results: 3
+  appraisal-policy: 4
+)
+
+cmw.json-record = [
+  type: cmw.media-type
+  value: cmw.base64url-string
+  ? ind: uint .bits cmw.cm-type
+]
+
+cmw.base64url-string = text .regexp "[A-Za-z0-9_-]+"
+
+;;;;;;;;;;;;;;;;
+;; EAT import ;;
+;;;;;;;;;;;;;;;;
+
+;# import eat
+
+eat.JSON-ONLY<J> = J .feature "json"
+eat.CBOR-ONLY<C> = C .feature "cbor"
+eat.JC<J,C> = eat.JSON-ONLY<J> / eat.CBOR-ONLY<C>

--- a/proto/doc.go
+++ b/proto/doc.go
@@ -1,0 +1,6 @@
+// Copyright 2025 Contributors to the Veraison project.
+// SPDX-License-Identifier: Apache-2.0
+
+package proto
+
+//go:generate protoc --go_out=. --go_opt=module=github.com/veraison/ratsd/proto --go-grpc_out=. --go-grpc_opt=module=github.com/veraison/ratsd/proto compositor.proto

--- a/proto/doc.go
+++ b/proto/doc.go
@@ -1,6 +1,0 @@
-// Copyright 2025 Contributors to the Veraison project.
-// SPDX-License-Identifier: Apache-2.0
-
-package proto
-
-//go:generate protoc --go_out=. --go_opt=module=github.com/veraison/ratsd/proto --go-grpc_out=. --go-grpc_opt=module=github.com/veraison/ratsd/proto compositor.proto


### PR DESCRIPTION
Added a CDDL spec for the upcoming RATSD token as well as for the current one (`-legacy`).

In the future, we may want to add some beautiful prose around this dry lump of code.  However, I am not planning to do that in this PR.