### PR TITLE
tsm: use tsm-report media types

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ the following example:
     "mock-tsm"
 ],
 "mock-tsm": {
-    "content-type": "application/vnd.veraison.configfs-tsm+json",
+    "content-type": "application/vnd.veraison.tsm-report+json",
     "privilege_level": "3"
 }
 ```

--- a/api/api.gen.go
+++ b/api/api.gen.go
@@ -42,7 +42,8 @@ const (
 
 // Defines values for CMWTyp.
 const (
-	ApplicationvndVeraisonConfigfsTsmJson CMWTyp = "application/vnd.veraison.configfs-tsm+json"
+	ApplicationvndVeraisonTsmReportCbor CMWTyp = "application/vnd.veraison.tsm-report+cbor"
+	ApplicationvndVeraisonTsmReportJson CMWTyp = "application/vnd.veraison.tsm-report+json"
 )
 
 // Defines values for EATEatProfile.

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -312,7 +312,7 @@ func TestRatsdChares_valid_request(t *testing.T) {
 			c, err := collection.GetCollectionItem("mock-tsm")
 			assert.NoError(t, err)
 			assert.Equal(t, cmw.KindMonad, c.GetKind())
-			assert.Equal(t, c.GetMonadType(), "application/vnd.veraison.configfs-tsm+json")
+			assert.Equal(t, c.GetMonadType(), tokens.TSMReportMediaTypeJSON)
 
 			tsmout := &tokens.TSMReport{}
 			tsmout.FromJSON(c.GetMonadValue())

--- a/attesters/mocktsm/mocktsm.go
+++ b/attesters/mocktsm/mocktsm.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	mediaType = "application/vnd.veraison.configfs-tsm+json"
+	mediaType = tokens.TSMReportMediaTypeJSON
 	nonceSize = 64
 )
 
@@ -106,7 +106,7 @@ func (m *MockPlugin) GetEvidence(in *compositor.EvidenceIn) *compositor.Evidence
 		level, err := strconv.Atoi(privlevel)
 		if err != nil || level < 0 {
 			errMsg := fmt.Errorf("privilege_level %s is invalid",
-			privlevel)
+				privlevel)
 			return getEvidenceError(errMsg, http.StatusBadRequest)
 		}
 		req.Privilege = &report.Privilege{Level: uint(level)}
@@ -131,8 +131,8 @@ func (m *MockPlugin) GetEvidence(in *compositor.EvidenceIn) *compositor.Evidence
 	}
 
 	return &compositor.EvidenceOut{
-		Status:   statusSucceeded,
-		Evidence: outEncoded,
+		Status:     statusSucceeded,
+		Evidence:   outEncoded,
 		StatusCode: http.StatusOK,
 	}
 }

--- a/attesters/tsm/tsm.go
+++ b/attesters/tsm/tsm.go
@@ -16,9 +16,7 @@ import (
 )
 
 const (
-	ApplicationvndVeraisonConfigfsTsmCbor = "application/vnd.veraison.configfs-tsm+cbor"
-	ApplicationvndVeraisonConfigfsTsmJson = "application/vnd.veraison.configfs-tsm+json"
-	tsmNonceSize                          = 64
+	tsmNonceSize = 64
 )
 
 var (
@@ -29,11 +27,11 @@ var (
 
 	supportedFormats = []*compositor.Format{
 		&compositor.Format{
-			ContentType: ApplicationvndVeraisonConfigfsTsmJson,
+			ContentType: tokens.TSMReportMediaTypeJSON,
 			NonceSize:   tsmNonceSize,
 		},
 		&compositor.Format{
-			ContentType: ApplicationvndVeraisonConfigfsTsmCbor,
+			ContentType: tokens.TSMReportMediaTypeCBOR,
 			NonceSize:   tsmNonceSize,
 		},
 	}
@@ -153,7 +151,7 @@ func (t *TSMPlugin) GetEvidence(in *compositor.EvidenceIn) *compositor.EvidenceO
 			var encodeOp func() ([]byte, error)
 			encodeAs := "JSON"
 
-			if in.ContentType == ApplicationvndVeraisonConfigfsTsmCbor {
+			if in.ContentType == tokens.TSMReportMediaTypeCBOR {
 				encodeOp = out.ToCBOR
 				encodeAs = "CBOR"
 			} else {
@@ -167,8 +165,8 @@ func (t *TSMPlugin) GetEvidence(in *compositor.EvidenceIn) *compositor.EvidenceO
 			}
 
 			return &compositor.EvidenceOut{
-				Status:   statusSucceeded,
-				Evidence: outEncoded,
+				Status:     statusSucceeded,
+				Evidence:   outEncoded,
 				StatusCode: http.StatusOK,
 			}
 		}

--- a/attesters/tsm/tsm_test.go
+++ b/attesters/tsm/tsm_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/go-configfs-tsm/configfs/linuxtsm"
 	"github.com/stretchr/testify/assert"
 	"github.com/veraison/ratsd/proto/compositor"
+	"github.com/veraison/ratsd/tokens"
 )
 
 const (
@@ -21,7 +22,7 @@ var (
 )
 
 func Test_getEvidenceError(t *testing.T) {
-	tests := []uint32 {http.StatusBadRequest, http.StatusBadRequest}
+	tests := []uint32{http.StatusBadRequest, http.StatusBadRequest}
 	for _, tt := range tests {
 		e := fmt.Errorf("sample error")
 
@@ -81,7 +82,7 @@ func Test_GetSupportedFormats(t *testing.T) {
 func Test_GetEvidence_wrong_nonce_size(t *testing.T) {
 	inblob := []byte("abcdefghijklmnopqrstuvwxyz123456")
 	in := &compositor.EvidenceIn{
-		ContentType: ApplicationvndVeraisonConfigfsTsmJson,
+		ContentType: tokens.TSMReportMediaTypeJSON,
 		Nonce:       inblob,
 	}
 
@@ -130,7 +131,7 @@ func TestGetEvidence_With_Invalid_Options(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			inblob := []byte(validNonceStr)
 			in := &compositor.EvidenceIn{
-				ContentType: ApplicationvndVeraisonConfigfsTsmJson,
+				ContentType: tokens.TSMReportMediaTypeJSON,
 				Nonce:       inblob,
 				Options:     []byte(tt.params),
 			}

--- a/docs/api/ratsd.yaml
+++ b/docs/api/ratsd.yaml
@@ -91,7 +91,8 @@ components:
         typ:
           type: string
           enum:
-            - application/vnd.veraison.configfs-tsm+json
+            - application/vnd.veraison.tsm-report+json
+            - application/vnd.veraison.tsm-report+cbor
         val:
           type: string
           format: base64url


### PR DESCRIPTION
## Summary
- switch TSM evidence media types to application/vnd.veraison.tsm-report in the attesters and generated API constants
- update the README example, API schema, and tests to match the new JSON and CBOR types

## Testing
- env GOCACHE=/tmp/go-build-cache go test -mod=mod ./api ./attesters/...