### PR TITLE
feat: Add legacy ratsd-token package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/spf13/viper v1.13.0
 	github.com/stretchr/testify v1.9.0
 	github.com/veraison/cmw v0.1.2-0.20250109140511-d907dcce0c61
+	github.com/veraison/eat v0.0.0-20220117140849-ddaf59d69f53
 	github.com/veraison/services v0.0.2501
 	go.uber.org/zap v1.23.0
 	golang.org/x/crypto v0.52.0

--- a/go.sum
+++ b/go.sum
@@ -87,6 +87,7 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwVZI=
 github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmVXmkdnm1bU=
+github.com/fxamacker/cbor/v2 v2.2.0/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
 github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv5E=
 github.com/fxamacker/cbor/v2 v2.7.0/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXEeXQVeNoDQ=
 github.com/gabriel-vasile/mimetype v1.4.3 h1:in2uUcidCuFcDKtdcBxlR0rJ1+fsokWf+uqxgUFjbI0=
@@ -321,6 +322,7 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
@@ -336,6 +338,8 @@ github.com/ugorji/go/codec v1.2.11 h1:BMaWp1Bb6fHwEtbplGBGJ498wD+LKlNSl25MjdZY4d
 github.com/ugorji/go/codec v1.2.11/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
 github.com/veraison/cmw v0.1.2-0.20250109140511-d907dcce0c61 h1:0m/q63xDHuFmfode99GCC7F9CHAREpS3QSa6uqayGFU=
 github.com/veraison/cmw v0.1.2-0.20250109140511-d907dcce0c61/go.mod h1:OiYKk1t6/Fmmg30ZpSMzi4nKr5kt3374sNTkgxC5BDs=
+github.com/veraison/eat v0.0.0-20220117140849-ddaf59d69f53 h1:5gnX2TrGd/Xz8DOp2OaLtg/jLoIubSUTrgz6iZ58pJ4=
+github.com/veraison/eat v0.0.0-20220117140849-ddaf59d69f53/go.mod h1:+kxt8iuFiVvKRs2VQ1Ho7bbAScXAB/kHFFuP5Biw19I=
 github.com/veraison/services v0.0.2501 h1:tK4a92RvceURIlT0pEkz3fU0TpaZ9jbcWqkPRkMsZXY=
 github.com/veraison/services v0.0.2501/go.mod h1:snBdw93xJ4j9sSrYueT3QlAB8oWGePwkq7H+kYf/lLc=
 github.com/vmware-labs/yaml-jsonpath v0.3.2 h1:/5QKeCBGdsInyDCyVNLbXyilb61MXGi9NP674f9Hobk=

--- a/ratsd-token/evidence.go
+++ b/ratsd-token/evidence.go
@@ -25,6 +25,35 @@ type Evidence struct {
 	Claims Claims `json:"-"`
 }
 
+// SetClaims attaches the supplied claims to the Evidence instance.
+// Only successfully validated claims are allowed to be set.
+func (e *Evidence) SetClaims(c Claims) error {
+	if e == nil {
+		return errors.New("nil evidence")
+	}
+
+	tmp := Evidence{Claims: c}
+	if err := tmp.Valid(); err != nil {
+		return fmt.Errorf("validation failed: %w", err)
+	}
+
+	e.Claims = c
+	return nil
+}
+
+// GetClaims returns the stored claims after validating the evidence state.
+func (e *Evidence) GetClaims() (c Claims, err error) {
+	if e == nil {
+		return c, errors.New("nil evidence")
+	}
+
+	if err = e.Valid(); err != nil {
+		return c, fmt.Errorf("validation failed: %w", err)
+	}
+
+	return e.Claims, nil
+}
+
 // Claims contains the legacy RATSD token claims defined in docs/ratsd-token.cddl.
 type Claims struct {
 	EatProfile          *eat.Profile    `json:"eat_profile"`

--- a/ratsd-token/evidence.go
+++ b/ratsd-token/evidence.go
@@ -29,7 +29,6 @@ var (
 	errMissingEatProfile          = errors.New(`missing mandatory claim "eat_profile"`)
 	errMissingEatNonce            = errors.New(`missing mandatory claim "eat_nonce"`)
 	errMissingCMW                 = errors.New(`missing mandatory claim "cmw"`)
-	errMissingNonceAdjustMap      = errors.New(`missing mandatory claim "vnd.veraison.nonce_adjust_map"`)
 	errMissingNonceAdjustFunction = errors.New(`missing mandatory claim "vnd.veraison.nonce_adjust_function"`)
 )
 
@@ -305,10 +304,6 @@ func (e *Evidence) Valid() error {
 		if *c.NonceAdjustFunction != NonceAdjustFunctionShake128 &&
 			*c.NonceAdjustFunction != NonceAdjustFunctionShake256 {
 			return fmt.Errorf(`invalid claim "vnd.veraison.nonce_adjust_function": %q`, *c.NonceAdjustFunction)
-		}
-
-		if c.NonceAdjustMap == nil {
-			return errMissingNonceAdjustMap
 		}
 	}
 

--- a/ratsd-token/evidence.go
+++ b/ratsd-token/evidence.go
@@ -137,7 +137,7 @@ func (c *Claims) GetKeyandNonceSz(key string) (uint, bool) {
 	return sz, ok
 }
 
-// SetCMW serializes the supplied CMW object into the legacy base64url claim form.
+// SetCMW serializes the supplied CMW object into the legacy base64 claim form.
 func (c *Claims) SetCMW(v interface{}) error {
 	if c == nil {
 		return errNilClaims
@@ -157,7 +157,7 @@ func (c *Claims) SetCMW(v interface{}) error {
 		return fmt.Errorf(`invalid claim "cmw": %w`, err)
 	}
 
-	c.CMW = base64.RawURLEncoding.EncodeToString(encoded)
+	c.CMW = base64.StdEncoding.EncodeToString(encoded)
 	return nil
 }
 
@@ -212,9 +212,9 @@ func (c *Claims) SetKeyandNonceSz(key string, sz uint) error {
 }
 
 func decodeLegacyCMW(v string) (*cmw.CMW, error) {
-	b, err := base64.RawURLEncoding.DecodeString(v)
+	b, err := base64.StdEncoding.DecodeString(v)
 	if err != nil {
-		return nil, fmt.Errorf("CMW base64url decoding failed: %w", err)
+		return nil, fmt.Errorf("CMW base64 decoding failed: %w", err)
 	}
 
 	var decoded cmw.CMW

--- a/ratsd-token/evidence.go
+++ b/ratsd-token/evidence.go
@@ -20,11 +20,11 @@ const (
 
 // Evidence exposes the legacy RATSD token as a single claims container.
 type Evidence struct {
-	Claims claims `json:"-"`
+	Claims Claims `json:"-"`
 }
 
-// claims contains the legacy RATSD token claims defined in docs/ratsd-token.cddl.
-type claims struct {
+// Claims contains the legacy RATSD token claims defined in docs/ratsd-token.cddl.
+type Claims struct {
 	EatProfile          *eat.Profile    `json:"eat_profile"`
 	EatNonce            *eat.Nonce      `json:"eat_nonce"`
 	CMW                 string          `json:"cmw"`
@@ -33,7 +33,7 @@ type claims struct {
 }
 
 // SetNonce replaces the stored EAT nonce with the supplied raw nonce value.
-func (c *claims) SetNonce(v []byte) error {
+func (c *Claims) SetNonce(v []byte) error {
 	if c == nil {
 		return errors.New("nil claims")
 	}
@@ -48,7 +48,7 @@ func (c *claims) SetNonce(v []byte) error {
 }
 
 // SetNonceAdjustFn sets the nonce adjustment algorithm.
-func (c *claims) SetNonceAdjustFn(alg string) error {
+func (c *Claims) SetNonceAdjustFn(alg string) error {
 	if c == nil {
 		return errors.New("nil claims")
 	}
@@ -65,7 +65,7 @@ func (c *claims) SetNonceAdjustFn(alg string) error {
 }
 
 // SetKeyandNonceSz sets the nonce-adjusted size for a given key.
-func (c *claims) SetKeyandNonceSz(key string, sz uint) error {
+func (c *Claims) SetKeyandNonceSz(key string, sz uint) error {
 	if c == nil {
 		return errors.New("nil claims")
 	}
@@ -90,7 +90,7 @@ func NewEvidence() *Evidence {
 	}
 
 	return &Evidence{
-		Claims: claims{
+		Claims: Claims{
 			EatProfile: profile,
 		},
 	}
@@ -168,7 +168,7 @@ func (e Evidence) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON decodes Evidence from the flat legacy claim layout.
 func (e *Evidence) UnmarshalJSON(data []byte) error {
-	var decoded claims
+	var decoded Claims
 	if err := json.Unmarshal(data, &decoded); err != nil {
 		return fmt.Errorf("JSON decoding failed: %w", err)
 	}

--- a/ratsd-token/evidence.go
+++ b/ratsd-token/evidence.go
@@ -1,0 +1,183 @@
+// Copyright 2025 Contributors to the Veraison project.
+// SPDX-License-Identifier: Apache-2.0
+package ratsdtoken
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/veraison/eat"
+)
+
+const (
+	LegacyProfile = "tag:github.com,2024:veraison/ratsd"
+	LegacyCMWType = "tag:github.com,2025:veraison/ratsd/cmw"
+
+	NonceAdjustFunctionShake128 = "shake-128"
+	NonceAdjustFunctionShake256 = "shake-256"
+)
+
+// Evidence exposes the legacy RATSD token as a single claims container.
+type Evidence struct {
+	Claims claims `json:"-"`
+}
+
+// claims contains the legacy RATSD token claims defined in docs/ratsd-token.cddl.
+type claims struct {
+	EatProfile          *eat.Profile    `json:"eat_profile"`
+	EatNonce            *eat.Nonce      `json:"eat_nonce"`
+	CMW                 string          `json:"cmw"`
+	NonceAdjustFunction *string         `json:"vnd.veraison.nonce_adjust_function,omitempty"`
+	NonceAdjustMap      map[string]uint `json:"vnd.veraison.nonce_adjust_map,omitempty"`
+}
+
+// SetNonce replaces the stored EAT nonce with the supplied raw nonce value.
+func (c *claims) SetNonce(v []byte) error {
+	if c == nil {
+		return errors.New("nil claims")
+	}
+
+	var nonce eat.Nonce
+	if err := nonce.Add(v); err != nil {
+		return err
+	}
+
+	c.EatNonce = &nonce
+	return nil
+}
+
+// SetNonceAdjustFn sets the nonce adjustment algorithm.
+func (c *claims) SetNonceAdjustFn(alg string) error {
+	if c == nil {
+		return errors.New("nil claims")
+	}
+
+	switch alg {
+	case NonceAdjustFunctionShake128, NonceAdjustFunctionShake256:
+		c.NonceAdjustFunction = &alg
+		return nil
+	case "":
+		return errors.New(`invalid claim "vnd.veraison.nonce_adjust_function": empty value`)
+	default:
+		return fmt.Errorf(`invalid claim "vnd.veraison.nonce_adjust_function": %q`, alg)
+	}
+}
+
+// SetKeyandNonceSz sets the nonce-adjusted size for a given key.
+func (c *claims) SetKeyandNonceSz(key string, sz uint) error {
+	if c == nil {
+		return errors.New("nil claims")
+	}
+
+	if key == "" {
+		return errors.New(`invalid claim "vnd.veraison.nonce_adjust_map": empty key`)
+	}
+
+	if c.NonceAdjustMap == nil {
+		c.NonceAdjustMap = make(map[string]uint)
+	}
+
+	c.NonceAdjustMap[key] = sz
+	return nil
+}
+
+// NewEvidence returns an Evidence with the legacy EAT profile preset.
+func NewEvidence() *Evidence {
+	profile, err := eat.NewProfile(LegacyProfile)
+	if err != nil {
+		panic(fmt.Sprintf("invalid legacy EAT profile constant: %v", err))
+	}
+
+	return &Evidence{
+		Claims: claims{
+			EatProfile: profile,
+		},
+	}
+}
+
+// Valid checks whether the Evidence matches the legacy RATSD token shape.
+func (e *Evidence) Valid() error {
+	if e == nil {
+		return errors.New("nil evidence")
+	}
+
+	c := e.Claims
+
+	if c.EatProfile == nil {
+		return errors.New(`missing mandatory claim "eat_profile"`)
+	}
+
+	profile, err := c.EatProfile.Get()
+	if err != nil {
+		return errors.New(`missing mandatory claim "eat_profile"`)
+	}
+
+	if profile != LegacyProfile {
+		return fmt.Errorf(`invalid claim "eat_profile": expected %q`, LegacyProfile)
+	}
+
+	if c.EatNonce == nil || c.EatNonce.Len() == 0 {
+		return errors.New(`missing mandatory claim "eat_nonce"`)
+	}
+
+	if err := c.EatNonce.Validate(); err != nil {
+		return fmt.Errorf(`invalid claim "eat_nonce": %w`, err)
+	}
+
+	if c.CMW == "" {
+		return errors.New(`missing mandatory claim "cmw"`)
+	}
+
+	if c.NonceAdjustFunction != nil {
+		if *c.NonceAdjustFunction == "" {
+			return errors.New(`invalid claim "vnd.veraison.nonce_adjust_function": empty value`)
+		}
+
+		if *c.NonceAdjustFunction != NonceAdjustFunctionShake128 &&
+			*c.NonceAdjustFunction != NonceAdjustFunctionShake256 {
+			return fmt.Errorf(`invalid claim "vnd.veraison.nonce_adjust_function": %q`, *c.NonceAdjustFunction)
+		}
+
+		if c.NonceAdjustMap == nil {
+			return errors.New(`missing mandatory claim "vnd.veraison.nonce_adjust_map"`)
+		}
+	}
+
+	if c.NonceAdjustMap != nil {
+		if len(c.NonceAdjustMap) == 0 {
+			return errors.New(`invalid claim "vnd.veraison.nonce_adjust_map": must contain at least one entry`)
+		}
+
+		if c.NonceAdjustFunction == nil {
+			return errors.New(`missing mandatory claim "vnd.veraison.nonce_adjust_function"`)
+		}
+	}
+
+	return nil
+}
+
+// MarshalJSON encodes Evidence using the flat legacy claim layout.
+func (e Evidence) MarshalJSON() ([]byte, error) {
+	if err := e.Valid(); err != nil {
+		return nil, fmt.Errorf("JSON encoding failed: %w", err)
+	}
+
+	return json.Marshal(e.Claims)
+}
+
+// UnmarshalJSON decodes Evidence from the flat legacy claim layout.
+func (e *Evidence) UnmarshalJSON(data []byte) error {
+	var decoded claims
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return fmt.Errorf("JSON decoding failed: %w", err)
+	}
+
+	tmp := Evidence{Claims: decoded}
+	if err := tmp.Valid(); err != nil {
+		return fmt.Errorf("JSON decoding failed: %w", err)
+	}
+
+	*e = tmp
+	return nil
+}

--- a/ratsd-token/evidence.go
+++ b/ratsd-token/evidence.go
@@ -128,6 +128,7 @@ func (c *Claims) GetNonceAdjustMap() map[string]uint {
 }
 
 // GetKeyandNonceSz returns the configured adjusted nonce size for the given key.
+// The boolean result reports whether the key was present in the nonce-adjust map.
 func (c *Claims) GetKeyandNonceSz(key string) (uint, bool) {
 	if c == nil || c.NonceAdjustMap == nil {
 		return 0, false

--- a/ratsd-token/evidence.go
+++ b/ratsd-token/evidence.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Contributors to the Veraison project.
+// Copyright 2026 Contributors to the Veraison project.
 // SPDX-License-Identifier: Apache-2.0
 package ratsdtoken
 

--- a/ratsd-token/evidence.go
+++ b/ratsd-token/evidence.go
@@ -20,6 +20,20 @@ const (
 	NonceAdjustFunctionShake256 = "shake-256"
 )
 
+var (
+	errNilEvidence                = errors.New("nil evidence")
+	errNilClaims                  = errors.New("nil claims")
+	errNilCMWValue                = errors.New(`invalid claim "cmw": nil value`)
+	errEmptyNonceAdjustFunction   = errors.New(`invalid claim "vnd.veraison.nonce_adjust_function": empty value`)
+	errEmptyNonceAdjustMapKey     = errors.New(`invalid claim "vnd.veraison.nonce_adjust_map": empty key`)
+	errMissingEatProfile          = errors.New(`missing mandatory claim "eat_profile"`)
+	errMissingEatNonce            = errors.New(`missing mandatory claim "eat_nonce"`)
+	errMissingCMW                 = errors.New(`missing mandatory claim "cmw"`)
+	errMissingNonceAdjustMap      = errors.New(`missing mandatory claim "vnd.veraison.nonce_adjust_map"`)
+	errEmptyNonceAdjustMap        = errors.New(`invalid claim "vnd.veraison.nonce_adjust_map": must contain at least one entry`)
+	errMissingNonceAdjustFunction = errors.New(`missing mandatory claim "vnd.veraison.nonce_adjust_function"`)
+)
+
 // Evidence exposes the legacy RATSD token as a single claims container.
 type Evidence struct {
 	Claims Claims `json:"-"`
@@ -29,7 +43,7 @@ type Evidence struct {
 // Only successfully validated claims are allowed to be set.
 func (e *Evidence) SetClaims(c Claims) error {
 	if e == nil {
-		return errors.New("nil evidence")
+		return errNilEvidence
 	}
 
 	tmp := Evidence{Claims: c}
@@ -44,7 +58,7 @@ func (e *Evidence) SetClaims(c Claims) error {
 // GetClaims returns the stored claims after validating the evidence state.
 func (e *Evidence) GetClaims() (c Claims, err error) {
 	if e == nil {
-		return c, errors.New("nil evidence")
+		return c, errNilEvidence
 	}
 
 	if err = e.Valid(); err != nil {
@@ -126,11 +140,11 @@ func (c *Claims) GetKeyandNonceSz(key string) (uint, bool) {
 // SetCMW serializes the supplied CMW object into the legacy base64url claim form.
 func (c *Claims) SetCMW(v interface{}) error {
 	if c == nil {
-		return errors.New("nil claims")
+		return errNilClaims
 	}
 
 	if v == nil {
-		return errors.New(`invalid claim "cmw": nil value`)
+		return errNilCMWValue
 	}
 
 	cmwValue, err := toCMW(v)
@@ -150,7 +164,7 @@ func (c *Claims) SetCMW(v interface{}) error {
 // SetNonce replaces the stored EAT nonce with the supplied raw nonce value.
 func (c *Claims) SetNonce(v []byte) error {
 	if c == nil {
-		return errors.New("nil claims")
+		return errNilClaims
 	}
 
 	var nonce eat.Nonce
@@ -165,7 +179,7 @@ func (c *Claims) SetNonce(v []byte) error {
 // SetNonceAdjustFn sets the nonce adjustment algorithm.
 func (c *Claims) SetNonceAdjustFn(alg string) error {
 	if c == nil {
-		return errors.New("nil claims")
+		return errNilClaims
 	}
 
 	switch alg {
@@ -173,7 +187,7 @@ func (c *Claims) SetNonceAdjustFn(alg string) error {
 		c.NonceAdjustFunction = &alg
 		return nil
 	case "":
-		return errors.New(`invalid claim "vnd.veraison.nonce_adjust_function": empty value`)
+		return errEmptyNonceAdjustFunction
 	default:
 		return fmt.Errorf(`invalid claim "vnd.veraison.nonce_adjust_function": %q`, alg)
 	}
@@ -182,11 +196,11 @@ func (c *Claims) SetNonceAdjustFn(alg string) error {
 // SetKeyandNonceSz sets the nonce-adjusted size for a given key.
 func (c *Claims) SetKeyandNonceSz(key string, sz uint) error {
 	if c == nil {
-		return errors.New("nil claims")
+		return errNilClaims
 	}
 
 	if key == "" {
-		return errors.New(`invalid claim "vnd.veraison.nonce_adjust_map": empty key`)
+		return errEmptyNonceAdjustMapKey
 	}
 
 	if c.NonceAdjustMap == nil {
@@ -221,7 +235,7 @@ func toCMW(v interface{}) (cmw.CMW, error) {
 
 	if value.Kind() == reflect.Ptr {
 		if value.IsNil() {
-			return cmw.CMW{}, errors.New(`invalid claim "cmw": nil value`)
+			return cmw.CMW{}, errNilCMWValue
 		}
 
 		elem := value.Elem()
@@ -250,18 +264,18 @@ func NewEvidence() *Evidence {
 // Valid checks whether the Evidence matches the legacy RATSD token shape.
 func (e *Evidence) Valid() error {
 	if e == nil {
-		return errors.New("nil evidence")
+		return errNilEvidence
 	}
 
 	c := e.Claims
 
 	if c.EatProfile == nil {
-		return errors.New(`missing mandatory claim "eat_profile"`)
+		return errMissingEatProfile
 	}
 
 	profile, err := c.EatProfile.Get()
 	if err != nil {
-		return errors.New(`missing mandatory claim "eat_profile"`)
+		return errMissingEatProfile
 	}
 
 	if profile != LegacyProfile {
@@ -269,7 +283,7 @@ func (e *Evidence) Valid() error {
 	}
 
 	if c.EatNonce == nil || c.EatNonce.Len() == 0 {
-		return errors.New(`missing mandatory claim "eat_nonce"`)
+		return errMissingEatNonce
 	}
 
 	if err := c.EatNonce.Validate(); err != nil {
@@ -277,7 +291,7 @@ func (e *Evidence) Valid() error {
 	}
 
 	if c.CMW == "" {
-		return errors.New(`missing mandatory claim "cmw"`)
+		return errMissingCMW
 	}
 
 	if _, err := decodeLegacyCMW(c.CMW); err != nil {
@@ -285,7 +299,7 @@ func (e *Evidence) Valid() error {
 	}
 	if c.NonceAdjustFunction != nil {
 		if *c.NonceAdjustFunction == "" {
-			return errors.New(`invalid claim "vnd.veraison.nonce_adjust_function": empty value`)
+			return errEmptyNonceAdjustFunction
 		}
 
 		if *c.NonceAdjustFunction != NonceAdjustFunctionShake128 &&
@@ -294,17 +308,17 @@ func (e *Evidence) Valid() error {
 		}
 
 		if c.NonceAdjustMap == nil {
-			return errors.New(`missing mandatory claim "vnd.veraison.nonce_adjust_map"`)
+			return errMissingNonceAdjustMap
 		}
 	}
 
 	if c.NonceAdjustMap != nil {
 		if len(c.NonceAdjustMap) == 0 {
-			return errors.New(`invalid claim "vnd.veraison.nonce_adjust_map": must contain at least one entry`)
+			return errEmptyNonceAdjustMap
 		}
 
 		if c.NonceAdjustFunction == nil {
-			return errors.New(`missing mandatory claim "vnd.veraison.nonce_adjust_function"`)
+			return errMissingNonceAdjustFunction
 		}
 	}
 

--- a/ratsd-token/evidence.go
+++ b/ratsd-token/evidence.go
@@ -32,6 +32,61 @@ type Claims struct {
 	NonceAdjustMap      map[string]uint `json:"vnd.veraison.nonce_adjust_map,omitempty"`
 }
 
+// GetEatProfile returns the EAT profile claim.
+func (c *Claims) GetEatProfile() *eat.Profile {
+	if c == nil {
+		return nil
+	}
+
+	return c.EatProfile
+}
+
+// GetEatNonce returns the EAT nonce claim.
+func (c *Claims) GetEatNonce() *eat.Nonce {
+	if c == nil {
+		return nil
+	}
+
+	return c.EatNonce
+}
+
+// GetCMW returns the legacy CMW collection claim.
+func (c *Claims) GetCMW() *cmw.CMW {
+	if c == nil {
+		return nil
+	}
+
+	return c.CMW
+}
+
+// GetNonceAdjustFn returns the nonce adjustment algorithm, if set.
+func (c *Claims) GetNonceAdjustFn() string {
+	if c == nil || c.NonceAdjustFunction == nil {
+		return ""
+	}
+
+	return *c.NonceAdjustFunction
+}
+
+// GetNonceAdjustMap returns the nonce adjustment map.
+func (c *Claims) GetNonceAdjustMap() map[string]uint {
+	if c == nil {
+		return nil
+	}
+
+	return c.NonceAdjustMap
+}
+
+// GetKeyandNonceSz returns the configured adjusted nonce size for the given key.
+func (c *Claims) GetKeyandNonceSz(key string) (uint, bool) {
+	if c == nil || c.NonceAdjustMap == nil {
+		return 0, false
+	}
+
+	sz, ok := c.NonceAdjustMap[key]
+	return sz, ok
+}
+
 // SetNonce replaces the stored EAT nonce with the supplied raw nonce value.
 func (c *Claims) SetNonce(v []byte) error {
 	if c == nil {

--- a/ratsd-token/evidence.go
+++ b/ratsd-token/evidence.go
@@ -53,17 +53,18 @@ func (e *Evidence) SetClaims(c Claims) error {
 	return nil
 }
 
-// GetClaims returns the stored claims after validating the evidence state.
-func (e *Evidence) GetClaims() (c Claims, err error) {
-	if e == nil {
-		return c, errNilEvidence
-	}
-
+// GetClaims returns a copy of the stored claims after validating the evidence state.
+func (e Evidence) GetClaims() (c Claims, err error) {
 	if err = e.Valid(); err != nil {
 		return c, fmt.Errorf("validation failed: %w", err)
 	}
 
-	return e.Claims, nil
+	c, err = cloneClaims(e.Claims)
+	if err != nil {
+		return c, fmt.Errorf("claims copy failed: %w", err)
+	}
+
+	return c, nil
 }
 
 // Claims contains the legacy RATSD token claims defined in docs/ratsd-token.cddl.
@@ -75,27 +76,100 @@ type Claims struct {
 	NonceAdjustMap      map[string]uint `json:"vnd.veraison.nonce_adjust_map,omitempty"`
 }
 
+func cloneClaims(c Claims) (Claims, error) {
+	clone := Claims{
+		CMW: c.CMW,
+	}
+
+	if c.EatProfile != nil {
+		profile, err := cloneEatProfile(c.EatProfile)
+		if err != nil {
+			return clone, fmt.Errorf(`invalid claim "eat_profile": %w`, err)
+		}
+		clone.EatProfile = profile
+	}
+
+	if c.EatNonce != nil {
+		nonce, err := cloneEatNonce(c.EatNonce)
+		if err != nil {
+			return clone, fmt.Errorf(`invalid claim "eat_nonce": %w`, err)
+		}
+		clone.EatNonce = nonce
+	}
+
+	if c.NonceAdjustFunction != nil {
+		nonceAdjustFunction := *c.NonceAdjustFunction
+		clone.NonceAdjustFunction = &nonceAdjustFunction
+	}
+
+	if c.NonceAdjustMap != nil {
+		clone.NonceAdjustMap = cloneNonceAdjustMap(c.NonceAdjustMap)
+	}
+
+	return clone, nil
+}
+
+func cloneEatProfile(v *eat.Profile) (*eat.Profile, error) {
+	profileValue, err := v.Get()
+	if err != nil {
+		return nil, err
+	}
+
+	return eat.NewProfile(profileValue)
+}
+
+func cloneEatNonce(v *eat.Nonce) (*eat.Nonce, error) {
+	var nonce eat.Nonce
+	for i := 0; i < v.Len(); i++ {
+		value := v.GetI(i)
+		if err := nonce.Add(append([]byte(nil), value...)); err != nil {
+			return nil, err
+		}
+	}
+
+	return &nonce, nil
+}
+
+func cloneNonceAdjustMap(v map[string]uint) map[string]uint {
+	clone := make(map[string]uint, len(v))
+	for k, value := range v {
+		clone[k] = value
+	}
+
+	return clone
+}
+
 // GetEatProfile returns the EAT profile claim.
-func (c *Claims) GetEatProfile() *eat.Profile {
-	if c == nil {
+func (c Claims) GetEatProfile() *eat.Profile {
+	if c.EatProfile == nil {
 		return nil
 	}
 
-	return c.EatProfile
+	profile, err := cloneEatProfile(c.EatProfile)
+	if err != nil {
+		return nil
+	}
+
+	return profile
 }
 
 // GetEatNonce returns the EAT nonce claim.
-func (c *Claims) GetEatNonce() *eat.Nonce {
-	if c == nil {
+func (c Claims) GetEatNonce() *eat.Nonce {
+	if c.EatNonce == nil {
 		return nil
 	}
 
-	return c.EatNonce
+	nonce, err := cloneEatNonce(c.EatNonce)
+	if err != nil {
+		return nil
+	}
+
+	return nonce
 }
 
 // GetCMW returns the legacy CMW collection claim.
-func (c *Claims) GetCMW() *cmw.CMW {
-	if c == nil || c.CMW == "" {
+func (c Claims) GetCMW() *cmw.CMW {
+	if c.CMW == "" {
 		return nil
 	}
 
@@ -108,27 +182,27 @@ func (c *Claims) GetCMW() *cmw.CMW {
 }
 
 // GetNonceAdjustFn returns the nonce adjustment algorithm, if set.
-func (c *Claims) GetNonceAdjustFn() string {
-	if c == nil || c.NonceAdjustFunction == nil {
+func (c Claims) GetNonceAdjustFn() string {
+	if c.NonceAdjustFunction == nil {
 		return ""
 	}
 
 	return *c.NonceAdjustFunction
 }
 
-// GetNonceAdjustMap returns the nonce adjustment map.
-func (c *Claims) GetNonceAdjustMap() map[string]uint {
-	if c == nil {
+// GetNonceAdjustMap returns a copy of the nonce adjustment map.
+func (c Claims) GetNonceAdjustMap() map[string]uint {
+	if c.NonceAdjustMap == nil {
 		return nil
 	}
 
-	return c.NonceAdjustMap
+	return cloneNonceAdjustMap(c.NonceAdjustMap)
 }
 
 // GetKeyandNonceSz returns the configured adjusted nonce size for the given key.
 // The boolean result reports whether the key was present in the nonce-adjust map.
-func (c *Claims) GetKeyandNonceSz(key string) (uint, bool) {
-	if c == nil || c.NonceAdjustMap == nil {
+func (c Claims) GetKeyandNonceSz(key string) (uint, bool) {
+	if c.NonceAdjustMap == nil {
 		return 0, false
 	}
 

--- a/ratsd-token/evidence.go
+++ b/ratsd-token/evidence.go
@@ -30,7 +30,6 @@ var (
 	errMissingEatNonce            = errors.New(`missing mandatory claim "eat_nonce"`)
 	errMissingCMW                 = errors.New(`missing mandatory claim "cmw"`)
 	errMissingNonceAdjustMap      = errors.New(`missing mandatory claim "vnd.veraison.nonce_adjust_map"`)
-	errEmptyNonceAdjustMap        = errors.New(`invalid claim "vnd.veraison.nonce_adjust_map": must contain at least one entry`)
 	errMissingNonceAdjustFunction = errors.New(`missing mandatory claim "vnd.veraison.nonce_adjust_function"`)
 )
 
@@ -314,10 +313,6 @@ func (e *Evidence) Valid() error {
 	}
 
 	if c.NonceAdjustMap != nil {
-		if len(c.NonceAdjustMap) == 0 {
-			return errEmptyNonceAdjustMap
-		}
-
 		if c.NonceAdjustFunction == nil {
 			return errMissingNonceAdjustFunction
 		}

--- a/ratsd-token/evidence.go
+++ b/ratsd-token/evidence.go
@@ -3,16 +3,18 @@
 package ratsdtoken
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
 
+	"github.com/veraison/cmw"
 	"github.com/veraison/eat"
 )
 
 const (
 	LegacyProfile = "tag:github.com,2024:veraison/ratsd"
-	LegacyCMWType = "tag:github.com,2025:veraison/ratsd/cmw"
 
 	NonceAdjustFunctionShake128 = "shake-128"
 	NonceAdjustFunctionShake256 = "shake-256"
@@ -52,11 +54,16 @@ func (c *Claims) GetEatNonce() *eat.Nonce {
 
 // GetCMW returns the legacy CMW collection claim.
 func (c *Claims) GetCMW() *cmw.CMW {
-	if c == nil {
+	if c == nil || c.CMW == "" {
 		return nil
 	}
 
-	return c.CMW
+	decoded, err := decodeLegacyCMW(c.CMW)
+	if err != nil {
+		return nil
+	}
+
+	return decoded
 }
 
 // GetNonceAdjustFn returns the nonce adjustment algorithm, if set.
@@ -85,6 +92,30 @@ func (c *Claims) GetKeyandNonceSz(key string) (uint, bool) {
 
 	sz, ok := c.NonceAdjustMap[key]
 	return sz, ok
+}
+
+// SetCMW serializes the supplied CMW object into the legacy base64url claim form.
+func (c *Claims) SetCMW(v interface{}) error {
+	if c == nil {
+		return errors.New("nil claims")
+	}
+
+	if v == nil {
+		return errors.New(`invalid claim "cmw": nil value`)
+	}
+
+	cmwValue, err := toCMW(v)
+	if err != nil {
+		return err
+	}
+
+	encoded, err := cmwValue.MarshalJSON()
+	if err != nil {
+		return fmt.Errorf(`invalid claim "cmw": %w`, err)
+	}
+
+	c.CMW = base64.RawURLEncoding.EncodeToString(encoded)
+	return nil
 }
 
 // SetNonce replaces the stored EAT nonce with the supplied raw nonce value.
@@ -137,6 +168,42 @@ func (c *Claims) SetKeyandNonceSz(key string, sz uint) error {
 	return nil
 }
 
+func decodeLegacyCMW(v string) (*cmw.CMW, error) {
+	b, err := base64.RawURLEncoding.DecodeString(v)
+	if err != nil {
+		return nil, fmt.Errorf("CMW base64url decoding failed: %w", err)
+	}
+
+	var decoded cmw.CMW
+	if err := decoded.UnmarshalJSON(b); err != nil {
+		return nil, fmt.Errorf("CMW JSON decoding failed: %w", err)
+	}
+
+	return &decoded, nil
+}
+
+func toCMW(v interface{}) (cmw.CMW, error) {
+	targetType := reflect.TypeOf(cmw.CMW{})
+	value := reflect.ValueOf(v)
+
+	if value.Type().ConvertibleTo(targetType) {
+		return value.Convert(targetType).Interface().(cmw.CMW), nil
+	}
+
+	if value.Kind() == reflect.Ptr {
+		if value.IsNil() {
+			return cmw.CMW{}, errors.New(`invalid claim "cmw": nil value`)
+		}
+
+		elem := value.Elem()
+		if elem.Type().ConvertibleTo(targetType) {
+			return elem.Convert(targetType).Interface().(cmw.CMW), nil
+		}
+	}
+
+	return cmw.CMW{}, fmt.Errorf(`invalid claim "cmw": %T`, v)
+}
+
 // NewEvidence returns an Evidence with the legacy EAT profile preset.
 func NewEvidence() *Evidence {
 	profile, err := eat.NewProfile(LegacyProfile)
@@ -184,6 +251,9 @@ func (e *Evidence) Valid() error {
 		return errors.New(`missing mandatory claim "cmw"`)
 	}
 
+	if _, err := decodeLegacyCMW(c.CMW); err != nil {
+		return fmt.Errorf(`invalid claim "cmw": %w`, err)
+	}
 	if c.NonceAdjustFunction != nil {
 		if *c.NonceAdjustFunction == "" {
 			return errors.New(`invalid claim "vnd.veraison.nonce_adjust_function": empty value`)

--- a/ratsd-token/evidence_test.go
+++ b/ratsd-token/evidence_test.go
@@ -243,17 +243,41 @@ func TestEvidenceGetClaimsFail(t *testing.T) {
 	assert.Equal(t, Claims{}, claims)
 }
 
-func TestEvidenceGetClaimsNilEvidence(t *testing.T) {
-	var evidence *Evidence
+func TestEvidenceGetClaimsZeroValue(t *testing.T) {
+	var evidence Evidence
 
 	claims, err := evidence.GetClaims()
 
-	assert.EqualError(t, err, "nil evidence")
+	assert.EqualError(t, err, `validation failed: missing mandatory claim "eat_profile"`)
 	assert.Equal(t, Claims{}, claims)
 }
 
-func TestClaimsGettersNilSafe(t *testing.T) {
-	var claimSet *Claims
+func TestEvidenceGetClaimsReturnsCopy(t *testing.T) {
+	evidence := validEvidence()
+	fn := NonceAdjustFunctionShake128
+	evidence.Claims.NonceAdjustFunction = &fn
+	evidence.Claims.NonceAdjustMap = map[string]uint{
+		"configfs-tsm": 32,
+	}
+
+	claims, err := evidence.GetClaims()
+	assert.NoError(t, err)
+
+	assert.NoError(t, claims.EatProfile.Set("tag:github.com,2026:veraison/ratsd/v2"))
+	claims.EatNonce.GetI(0)[0] = 'x'
+	*claims.NonceAdjustFunction = NonceAdjustFunctionShake256
+	claims.NonceAdjustMap["configfs-tsm"] = 64
+
+	profile, err := evidence.Claims.EatProfile.Get()
+	assert.NoError(t, err)
+	assert.Equal(t, LegacyProfile, profile)
+	assert.Equal(t, []byte("12345678"), evidence.Claims.EatNonce.GetI(0))
+	assert.Equal(t, NonceAdjustFunctionShake128, *evidence.Claims.NonceAdjustFunction)
+	assert.Equal(t, map[string]uint{"configfs-tsm": 32}, evidence.Claims.NonceAdjustMap)
+}
+
+func TestClaimsGettersZeroValue(t *testing.T) {
+	var claimSet Claims
 
 	assert.Nil(t, claimSet.GetEatProfile())
 	assert.Nil(t, claimSet.GetEatNonce())
@@ -273,8 +297,19 @@ func TestClaimsGettersPass(t *testing.T) {
 		"configfs-tsm": 32,
 	}
 
-	assert.Same(t, evidence.Claims.EatProfile, evidence.Claims.GetEatProfile())
-	assert.Same(t, evidence.Claims.EatNonce, evidence.Claims.GetEatNonce())
+	profile := evidence.Claims.GetEatProfile()
+	if assert.NotNil(t, profile) {
+		profileValue, err := profile.Get()
+		assert.NoError(t, err)
+		assert.Equal(t, LegacyProfile, profileValue)
+	}
+
+	nonce := evidence.Claims.GetEatNonce()
+	if assert.NotNil(t, nonce) {
+		assert.Equal(t, 1, nonce.Len())
+		assert.Equal(t, []byte("12345678"), nonce.GetI(0))
+	}
+
 	expectedCMW, _ := makeLegacyCMW(t)
 	assertCMWEquivalent(t, expectedCMW, evidence.Claims.GetCMW())
 	assert.Equal(t, NonceAdjustFunctionShake128, evidence.Claims.GetNonceAdjustFn())
@@ -282,6 +317,32 @@ func TestClaimsGettersPass(t *testing.T) {
 	sz, ok := evidence.Claims.GetKeyandNonceSz("configfs-tsm")
 	assert.True(t, ok)
 	assert.Equal(t, uint(32), sz)
+}
+
+func TestClaimsGettersReturnCopies(t *testing.T) {
+	evidence := validEvidence()
+	fn := NonceAdjustFunctionShake128
+	evidence.Claims.NonceAdjustFunction = &fn
+	evidence.Claims.NonceAdjustMap = map[string]uint{
+		"configfs-tsm": 32,
+	}
+
+	profile := evidence.Claims.GetEatProfile()
+	nonce := evidence.Claims.GetEatNonce()
+	nonceAdjustMap := evidence.Claims.GetNonceAdjustMap()
+	if !assert.NotNil(t, profile) || !assert.NotNil(t, nonce) || !assert.NotNil(t, nonceAdjustMap) {
+		return
+	}
+
+	assert.NoError(t, profile.Set("tag:github.com,2026:veraison/ratsd/v2"))
+	nonce.GetI(0)[0] = 'x'
+	nonceAdjustMap["configfs-tsm"] = 64
+
+	profileValue, err := evidence.Claims.EatProfile.Get()
+	assert.NoError(t, err)
+	assert.Equal(t, LegacyProfile, profileValue)
+	assert.Equal(t, []byte("12345678"), evidence.Claims.EatNonce.GetI(0))
+	assert.Equal(t, map[string]uint{"configfs-tsm": 32}, evidence.Claims.NonceAdjustMap)
 }
 
 func TestEvidenceValidFailWrongProfile(t *testing.T) {

--- a/ratsd-token/evidence_test.go
+++ b/ratsd-token/evidence_test.go
@@ -293,6 +293,15 @@ func TestEvidenceValidFailWrongProfile(t *testing.T) {
 	assert.EqualError(t, evidence.Valid(), `invalid claim "eat_profile": expected "tag:github.com,2024:veraison/ratsd"`)
 }
 
+func TestEvidenceValidPassEmptyNonceAdjustMap(t *testing.T) {
+	evidence := validEvidence()
+	fn := NonceAdjustFunctionShake256
+	evidence.Claims.NonceAdjustFunction = &fn
+	evidence.Claims.NonceAdjustMap = map[string]uint{}
+
+	assert.NoError(t, evidence.Valid())
+}
+
 func TestEvidenceValidFailIncompleteNonceAdjustGroup(t *testing.T) {
 	evidence := validEvidence()
 	fn := NonceAdjustFunctionShake256

--- a/ratsd-token/evidence_test.go
+++ b/ratsd-token/evidence_test.go
@@ -1,0 +1,155 @@
+// Copyright 2025 Contributors to the Veraison project.
+// SPDX-License-Identifier: Apache-2.0
+package ratsdtoken
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/veraison/eat"
+)
+
+func validEvidence() *Evidence {
+	profile, err := eat.NewProfile(LegacyProfile)
+	if err != nil {
+		panic(err)
+	}
+
+	var claimSet claims
+	if err := claimSet.SetNonce([]byte("12345678")); err != nil {
+		panic(err)
+	}
+	claimSet.EatProfile = profile
+	claimSet.CMW = "ZXhhbXBsZS1jbXc"
+
+	return &Evidence{
+		Claims: claimSet,
+	}
+}
+
+func assertEvidenceEquivalent(t *testing.T, expected, actual *Evidence) {
+	t.Helper()
+
+	if assert.NotNil(t, expected.Claims.EatProfile) && assert.NotNil(t, actual.Claims.EatProfile) {
+		expectedProfile, err := expected.Claims.EatProfile.Get()
+		assert.NoError(t, err)
+		actualProfile, err := actual.Claims.EatProfile.Get()
+		assert.NoError(t, err)
+		assert.Equal(t, expectedProfile, actualProfile)
+	}
+
+	if assert.NotNil(t, expected.Claims.EatNonce) && assert.NotNil(t, actual.Claims.EatNonce) {
+		assert.Equal(t, expected.Claims.EatNonce.Len(), actual.Claims.EatNonce.Len())
+		for i := 0; i < expected.Claims.EatNonce.Len(); i++ {
+			assert.Equal(t, expected.Claims.EatNonce.GetI(i), actual.Claims.EatNonce.GetI(i))
+		}
+	}
+
+	assert.Equal(t, expected.Claims.NonceAdjustFunction, actual.Claims.NonceAdjustFunction)
+	assert.Equal(t, expected.Claims.NonceAdjustMap, actual.Claims.NonceAdjustMap)
+	assert.Equal(t, expected.Claims.CMW, actual.Claims.CMW)
+}
+
+func TestNewEvidence(t *testing.T) {
+	evidence := NewEvidence()
+
+	if assert.NotNil(t, evidence.Claims.EatProfile) {
+		profile, err := evidence.Claims.EatProfile.Get()
+		assert.NoError(t, err)
+		assert.Equal(t, LegacyProfile, profile)
+	}
+}
+
+func TestClaimsSetNonce(t *testing.T) {
+	var claimSet claims
+
+	assert.NoError(t, claimSet.SetNonce([]byte("abcdefgh")))
+	if assert.NotNil(t, claimSet.EatNonce) {
+		assert.Equal(t, 1, claimSet.EatNonce.Len())
+		assert.Equal(t, []byte("abcdefgh"), claimSet.EatNonce.GetI(0))
+	}
+}
+
+func TestClaimsSetNonceFail(t *testing.T) {
+	var claimSet claims
+
+	assert.EqualError(t, claimSet.SetNonce([]byte("short")), "a nonce must be between 8 and 64 bytes long; found 5")
+	assert.Nil(t, claimSet.EatNonce)
+}
+
+func TestClaimsSetNonceAdjustFn(t *testing.T) {
+	var claimSet claims
+
+	assert.NoError(t, claimSet.SetNonceAdjustFn(NonceAdjustFunctionShake256))
+	if assert.NotNil(t, claimSet.NonceAdjustFunction) {
+		assert.Equal(t, NonceAdjustFunctionShake256, *claimSet.NonceAdjustFunction)
+	}
+}
+
+func TestClaimsSetNonceAdjustFnFail(t *testing.T) {
+	var claimSet claims
+
+	assert.EqualError(t, claimSet.SetNonceAdjustFn("sha-256"), `invalid claim "vnd.veraison.nonce_adjust_function": "sha-256"`)
+	assert.Nil(t, claimSet.NonceAdjustFunction)
+}
+
+func TestClaimsSetKeyandNonceSz(t *testing.T) {
+	var claimSet claims
+
+	assert.NoError(t, claimSet.SetKeyandNonceSz("configfs-tsm", 32))
+	assert.Equal(t, map[string]uint{"configfs-tsm": 32}, claimSet.NonceAdjustMap)
+}
+
+func TestClaimsSetKeyandNonceSzFail(t *testing.T) {
+	var claimSet claims
+
+	assert.EqualError(t, claimSet.SetKeyandNonceSz("", 32), `invalid claim "vnd.veraison.nonce_adjust_map": empty key`)
+	assert.Nil(t, claimSet.NonceAdjustMap)
+}
+
+func TestEvidenceValidPass(t *testing.T) {
+	evidence := validEvidence()
+
+	assert.NoError(t, evidence.Valid())
+}
+
+func TestEvidenceValidFailWrongProfile(t *testing.T) {
+	evidence := validEvidence()
+	profile, err := eat.NewProfile("tag:github.com,2026:veraison/ratsd/v2")
+	assert.NoError(t, err)
+	evidence.Claims.EatProfile = profile
+
+	assert.EqualError(t, evidence.Valid(), `invalid claim "eat_profile": expected "tag:github.com,2024:veraison/ratsd"`)
+}
+
+func TestEvidenceValidFailIncompleteNonceAdjustGroup(t *testing.T) {
+	evidence := validEvidence()
+	fn := NonceAdjustFunctionShake256
+	evidence.Claims.NonceAdjustFunction = &fn
+
+	assert.EqualError(t, evidence.Valid(), `missing mandatory claim "vnd.veraison.nonce_adjust_map"`)
+}
+
+func TestEvidenceJSONSerDesPass(t *testing.T) {
+	evidence := validEvidence()
+	fn := NonceAdjustFunctionShake128
+	evidence.Claims.NonceAdjustFunction = &fn
+	evidence.Claims.NonceAdjustMap = map[string]uint{
+		"configfs-tsm": 32,
+	}
+
+	encodedJSON, err := json.Marshal(evidence)
+	assert.NoError(t, err)
+
+	var encodedClaims map[string]any
+	assert.NoError(t, json.Unmarshal(encodedJSON, &encodedClaims))
+	assert.Equal(t, LegacyProfile, encodedClaims["eat_profile"])
+	assert.Equal(t, "MTIzNDU2Nzg=", encodedClaims["eat_nonce"])
+	assert.Equal(t, evidence.Claims.CMW, encodedClaims["cmw"])
+	assert.NotContains(t, encodedClaims, "claims")
+
+	decodedEvidence := &Evidence{}
+	assert.NoError(t, json.Unmarshal(encodedJSON, decodedEvidence))
+	assertEvidenceEquivalent(t, evidence, decodedEvidence)
+}

--- a/ratsd-token/evidence_test.go
+++ b/ratsd-token/evidence_test.go
@@ -49,7 +49,7 @@ func makeLegacyCMWForTest() (*cmw.CMW, string) {
 		panic(err)
 	}
 
-	return collection, base64.RawURLEncoding.EncodeToString(encoded)
+	return collection, base64.StdEncoding.EncodeToString(encoded)
 }
 
 func makeLegacyCMW(t *testing.T) (*cmw.CMW, string) {

--- a/ratsd-token/evidence_test.go
+++ b/ratsd-token/evidence_test.go
@@ -3,10 +3,12 @@
 package ratsdtoken
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/veraison/cmw"
 	"github.com/veraison/eat"
 )
 
@@ -21,11 +23,58 @@ func validEvidence() *Evidence {
 		panic(err)
 	}
 	claimSet.EatProfile = profile
-	claimSet.CMW = "ZXhhbXBsZS1jbXc"
+	collection, _ := makeLegacyCMWForTest()
+	if err := claimSet.SetCMW(collection); err != nil {
+		panic(err)
+	}
 
 	return &Evidence{
 		Claims: claimSet,
 	}
+}
+
+func makeLegacyCMWForTest() (*cmw.CMW, string) {
+	collection := cmw.NewCollection("tag:github.com,2025:veraison/ratsd/cmw")
+	if collection == nil {
+		panic("failed to create legacy CMW collection")
+	}
+
+	node := cmw.NewMonad("application/octet-stream", []byte{0x01, 0x02, 0x03})
+	if err := collection.AddCollectionItem("mock-tsm", node); err != nil {
+		panic(err)
+	}
+
+	encoded, err := collection.MarshalJSON()
+	if err != nil {
+		panic(err)
+	}
+
+	return collection, base64.RawURLEncoding.EncodeToString(encoded)
+}
+
+func makeLegacyCMW(t *testing.T) (*cmw.CMW, string) {
+	t.Helper()
+
+	collection, encoded := makeLegacyCMWForTest()
+	if !assert.NotNil(t, collection) {
+		return nil, ""
+	}
+
+	return collection, encoded
+}
+
+func assertCMWEquivalent(t *testing.T, expected, actual *cmw.CMW) {
+	t.Helper()
+
+	if !assert.NotNil(t, expected) || !assert.NotNil(t, actual) {
+		return
+	}
+
+	expectedJSON, err := expected.MarshalJSON()
+	assert.NoError(t, err)
+	actualJSON, err := actual.MarshalJSON()
+	assert.NoError(t, err)
+	assert.Equal(t, expectedJSON, actualJSON)
 }
 func assertEvidenceEquivalent(t *testing.T, expected, actual *Evidence) {
 	t.Helper()
@@ -92,6 +141,31 @@ func TestClaimsSetNonceAdjustFnFail(t *testing.T) {
 	assert.Nil(t, claimSet.NonceAdjustFunction)
 }
 
+func TestClaimsSetCMW(t *testing.T) {
+	var claimSet Claims
+	collection, expected := makeLegacyCMW(t)
+
+	assert.NoError(t, claimSet.SetCMW(collection))
+	assert.Equal(t, expected, claimSet.CMW)
+	assertCMWEquivalent(t, collection, claimSet.GetCMW())
+}
+
+func TestClaimsSetCMWFromValue(t *testing.T) {
+	var claimSet Claims
+	collection, expected := makeLegacyCMW(t)
+
+	assert.NoError(t, claimSet.SetCMW(*collection))
+	assert.Equal(t, expected, claimSet.CMW)
+	assertCMWEquivalent(t, collection, claimSet.GetCMW())
+}
+
+func TestClaimsSetCMWFail(t *testing.T) {
+	var claimSet Claims
+
+	assert.EqualError(t, claimSet.SetCMW("not-a-cmw"), `invalid claim "cmw": string`)
+	assert.Nil(t, claimSet.GetCMW())
+}
+
 func TestClaimsSetKeyandNonceSz(t *testing.T) {
 	var claimSet Claims
 
@@ -138,7 +212,8 @@ func TestClaimsGettersPass(t *testing.T) {
 
 	assert.Same(t, evidence.Claims.EatProfile, evidence.Claims.GetEatProfile())
 	assert.Same(t, evidence.Claims.EatNonce, evidence.Claims.GetEatNonce())
-	assert.Same(t, evidence.Claims.CMW, evidence.Claims.GetCMW())
+	expectedCMW, _ := makeLegacyCMW(t)
+	assertCMWEquivalent(t, expectedCMW, evidence.Claims.GetCMW())
 	assert.Equal(t, NonceAdjustFunctionShake128, evidence.Claims.GetNonceAdjustFn())
 	assert.Equal(t, map[string]uint{"configfs-tsm": 32}, evidence.Claims.GetNonceAdjustMap())
 	sz, ok := evidence.Claims.GetKeyandNonceSz("configfs-tsm")

--- a/ratsd-token/evidence_test.go
+++ b/ratsd-token/evidence_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Contributors to the Veraison project.
+// Copyright 2026 Contributors to the Veraison project.
 // SPDX-License-Identifier: Apache-2.0
 package ratsdtoken
 

--- a/ratsd-token/evidence_test.go
+++ b/ratsd-token/evidence_test.go
@@ -64,9 +64,10 @@ func TestClaimsSetNonce(t *testing.T) {
 	var claimSet Claims
 
 	assert.NoError(t, claimSet.SetNonce([]byte("abcdefgh")))
-	if assert.NotNil(t, claimSet.EatNonce) {
-		assert.Equal(t, 1, claimSet.EatNonce.Len())
-		assert.Equal(t, []byte("abcdefgh"), claimSet.EatNonce.GetI(0))
+	nonce := claimSet.GetEatNonce()
+	if assert.NotNil(t, nonce) {
+		assert.Equal(t, 1, nonce.Len())
+		assert.Equal(t, []byte("abcdefgh"), nonce.GetI(0))
 	}
 }
 
@@ -81,9 +82,7 @@ func TestClaimsSetNonceAdjustFn(t *testing.T) {
 	var claimSet Claims
 
 	assert.NoError(t, claimSet.SetNonceAdjustFn(NonceAdjustFunctionShake256))
-	if assert.NotNil(t, claimSet.NonceAdjustFunction) {
-		assert.Equal(t, NonceAdjustFunctionShake256, *claimSet.NonceAdjustFunction)
-	}
+	assert.Equal(t, NonceAdjustFunctionShake256, claimSet.GetNonceAdjustFn())
 }
 
 func TestClaimsSetNonceAdjustFnFail(t *testing.T) {
@@ -97,7 +96,10 @@ func TestClaimsSetKeyandNonceSz(t *testing.T) {
 	var claimSet Claims
 
 	assert.NoError(t, claimSet.SetKeyandNonceSz("configfs-tsm", 32))
-	assert.Equal(t, map[string]uint{"configfs-tsm": 32}, claimSet.NonceAdjustMap)
+	assert.Equal(t, map[string]uint{"configfs-tsm": 32}, claimSet.GetNonceAdjustMap())
+	sz, ok := claimSet.GetKeyandNonceSz("configfs-tsm")
+	assert.True(t, ok)
+	assert.Equal(t, uint(32), sz)
 }
 
 func TestClaimsSetKeyandNonceSzFail(t *testing.T) {
@@ -111,6 +113,37 @@ func TestEvidenceValidPass(t *testing.T) {
 	evidence := validEvidence()
 
 	assert.NoError(t, evidence.Valid())
+}
+
+func TestClaimsGettersNilSafe(t *testing.T) {
+	var claimSet *Claims
+
+	assert.Nil(t, claimSet.GetEatProfile())
+	assert.Nil(t, claimSet.GetEatNonce())
+	assert.Nil(t, claimSet.GetCMW())
+	assert.Equal(t, "", claimSet.GetNonceAdjustFn())
+	assert.Nil(t, claimSet.GetNonceAdjustMap())
+	sz, ok := claimSet.GetKeyandNonceSz("configfs-tsm")
+	assert.False(t, ok)
+	assert.Equal(t, uint(0), sz)
+}
+
+func TestClaimsGettersPass(t *testing.T) {
+	evidence := validEvidence()
+	fn := NonceAdjustFunctionShake128
+	evidence.Claims.NonceAdjustFunction = &fn
+	evidence.Claims.NonceAdjustMap = map[string]uint{
+		"configfs-tsm": 32,
+	}
+
+	assert.Same(t, evidence.Claims.EatProfile, evidence.Claims.GetEatProfile())
+	assert.Same(t, evidence.Claims.EatNonce, evidence.Claims.GetEatNonce())
+	assert.Same(t, evidence.Claims.CMW, evidence.Claims.GetCMW())
+	assert.Equal(t, NonceAdjustFunctionShake128, evidence.Claims.GetNonceAdjustFn())
+	assert.Equal(t, map[string]uint{"configfs-tsm": 32}, evidence.Claims.GetNonceAdjustMap())
+	sz, ok := evidence.Claims.GetKeyandNonceSz("configfs-tsm")
+	assert.True(t, ok)
+	assert.Equal(t, uint(32), sz)
 }
 
 func TestEvidenceValidFailWrongProfile(t *testing.T) {

--- a/ratsd-token/evidence_test.go
+++ b/ratsd-token/evidence_test.go
@@ -16,7 +16,7 @@ func validEvidence() *Evidence {
 		panic(err)
 	}
 
-	var claimSet claims
+	var claimSet Claims
 	if err := claimSet.SetNonce([]byte("12345678")); err != nil {
 		panic(err)
 	}
@@ -27,7 +27,6 @@ func validEvidence() *Evidence {
 		Claims: claimSet,
 	}
 }
-
 func assertEvidenceEquivalent(t *testing.T, expected, actual *Evidence) {
 	t.Helper()
 
@@ -62,7 +61,7 @@ func TestNewEvidence(t *testing.T) {
 }
 
 func TestClaimsSetNonce(t *testing.T) {
-	var claimSet claims
+	var claimSet Claims
 
 	assert.NoError(t, claimSet.SetNonce([]byte("abcdefgh")))
 	if assert.NotNil(t, claimSet.EatNonce) {
@@ -72,14 +71,14 @@ func TestClaimsSetNonce(t *testing.T) {
 }
 
 func TestClaimsSetNonceFail(t *testing.T) {
-	var claimSet claims
+	var claimSet Claims
 
 	assert.EqualError(t, claimSet.SetNonce([]byte("short")), "a nonce must be between 8 and 64 bytes long; found 5")
 	assert.Nil(t, claimSet.EatNonce)
 }
 
 func TestClaimsSetNonceAdjustFn(t *testing.T) {
-	var claimSet claims
+	var claimSet Claims
 
 	assert.NoError(t, claimSet.SetNonceAdjustFn(NonceAdjustFunctionShake256))
 	if assert.NotNil(t, claimSet.NonceAdjustFunction) {
@@ -88,21 +87,21 @@ func TestClaimsSetNonceAdjustFn(t *testing.T) {
 }
 
 func TestClaimsSetNonceAdjustFnFail(t *testing.T) {
-	var claimSet claims
+	var claimSet Claims
 
 	assert.EqualError(t, claimSet.SetNonceAdjustFn("sha-256"), `invalid claim "vnd.veraison.nonce_adjust_function": "sha-256"`)
 	assert.Nil(t, claimSet.NonceAdjustFunction)
 }
 
 func TestClaimsSetKeyandNonceSz(t *testing.T) {
-	var claimSet claims
+	var claimSet Claims
 
 	assert.NoError(t, claimSet.SetKeyandNonceSz("configfs-tsm", 32))
 	assert.Equal(t, map[string]uint{"configfs-tsm": 32}, claimSet.NonceAdjustMap)
 }
 
 func TestClaimsSetKeyandNonceSzFail(t *testing.T) {
-	var claimSet claims
+	var claimSet Claims
 
 	assert.EqualError(t, claimSet.SetKeyandNonceSz("", 32), `invalid claim "vnd.veraison.nonce_adjust_map": empty key`)
 	assert.Nil(t, claimSet.NonceAdjustMap)

--- a/ratsd-token/evidence_test.go
+++ b/ratsd-token/evidence_test.go
@@ -189,6 +189,69 @@ func TestEvidenceValidPass(t *testing.T) {
 	assert.NoError(t, evidence.Valid())
 }
 
+func TestEvidenceSetClaimsPass(t *testing.T) {
+	src := validEvidence()
+
+	var evidence Evidence
+	err := evidence.SetClaims(src.Claims)
+
+	assert.NoError(t, err)
+	assertEvidenceEquivalent(t, src, &evidence)
+}
+
+func TestEvidenceSetClaimsFail(t *testing.T) {
+	valid := validEvidence()
+	invalid := validEvidence().Claims
+	invalid.CMW = ""
+
+	evidence := Evidence{Claims: valid.Claims}
+	err := evidence.SetClaims(invalid)
+
+	assert.EqualError(t, err, `validation failed: missing mandatory claim "cmw"`)
+	assertEvidenceEquivalent(t, valid, &evidence)
+}
+
+func TestEvidenceSetClaimsNilEvidence(t *testing.T) {
+	var evidence *Evidence
+
+	err := evidence.SetClaims(Claims{})
+
+	assert.EqualError(t, err, "nil evidence")
+}
+
+func TestEvidenceGetClaimsPass(t *testing.T) {
+	evidence := validEvidence()
+	fn := NonceAdjustFunctionShake128
+	evidence.Claims.NonceAdjustFunction = &fn
+	evidence.Claims.NonceAdjustMap = map[string]uint{
+		"configfs-tsm": 32,
+	}
+
+	actual, err := evidence.GetClaims()
+
+	assert.NoError(t, err)
+	assertEvidenceEquivalent(t, evidence, &Evidence{Claims: actual})
+}
+
+func TestEvidenceGetClaimsFail(t *testing.T) {
+	evidence := validEvidence()
+	evidence.Claims.CMW = ""
+
+	claims, err := evidence.GetClaims()
+
+	assert.EqualError(t, err, `validation failed: missing mandatory claim "cmw"`)
+	assert.Equal(t, Claims{}, claims)
+}
+
+func TestEvidenceGetClaimsNilEvidence(t *testing.T) {
+	var evidence *Evidence
+
+	claims, err := evidence.GetClaims()
+
+	assert.EqualError(t, err, "nil evidence")
+	assert.Equal(t, Claims{}, claims)
+}
+
 func TestClaimsGettersNilSafe(t *testing.T) {
 	var claimSet *Claims
 

--- a/ratsd-token/evidence_test.go
+++ b/ratsd-token/evidence_test.go
@@ -302,12 +302,12 @@ func TestEvidenceValidPassEmptyNonceAdjustMap(t *testing.T) {
 	assert.NoError(t, evidence.Valid())
 }
 
-func TestEvidenceValidFailIncompleteNonceAdjustGroup(t *testing.T) {
+func TestEvidenceValidPassNilNonceAdjustMap(t *testing.T) {
 	evidence := validEvidence()
 	fn := NonceAdjustFunctionShake256
 	evidence.Claims.NonceAdjustFunction = &fn
 
-	assert.EqualError(t, evidence.Valid(), `missing mandatory claim "vnd.veraison.nonce_adjust_map"`)
+	assert.NoError(t, evidence.Valid())
 }
 
 func TestEvidenceJSONSerDesPass(t *testing.T) {


### PR DESCRIPTION
Add a reusable ratsd-token library for the legacy token. The support for v2, and the adoption of the to ratsd-token library in ratsd main application, will be added in separated PRs.