### PR TITLE
ratsd-token-v2: initialize CBOR modes in init

### DIFF
--- a/ratsd-token-v2/cbor.go
+++ b/ratsd-token-v2/cbor.go
@@ -1,0 +1,58 @@
+// Copyright 2026 Contributors to the Veraison project.
+// SPDX-License-Identifier: Apache-2.0
+package ratsdtokenv2
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/fxamacker/cbor/v2"
+)
+
+var (
+	encMode       cbor.EncMode
+	decMode       cbor.DecMode
+	claimsEncMode cbor.EncMode
+	claimsDecMode cbor.DecMode
+)
+
+func init() {
+	var err error
+
+	encMode, err = cbor.CoreDetEncOptions().EncMode()
+	if err != nil {
+		panic(fmt.Sprintf("CBOR encoder initialization failed: %v", err))
+	}
+
+	decMode, err = cbor.DecOptions{}.DecMode()
+	if err != nil {
+		panic(fmt.Sprintf("CBOR decoder initialization failed: %v", err))
+	}
+
+	claimsTagSet := newClaimsTagSet()
+	claimsEncMode, err = cbor.CoreDetEncOptions().EncModeWithTags(claimsTagSet)
+	if err != nil {
+		panic(fmt.Sprintf("CBOR claims encoder initialization failed: %v", err))
+	}
+
+	claimsDecMode, err = cbor.DecOptions{
+		DupMapKey:         cbor.DupMapKeyEnforcedAPF,
+		ExtraReturnErrors: cbor.ExtraDecErrorUnknownField,
+	}.DecModeWithTags(claimsTagSet)
+	if err != nil {
+		panic(fmt.Sprintf("CBOR claims decoder initialization failed: %v", err))
+	}
+}
+
+func newClaimsTagSet() cbor.TagSet {
+	tags := cbor.NewTagSet()
+	if err := tags.Add(
+		cbor.TagOptions{EncTag: cbor.EncTagRequired, DecTag: cbor.DecTagRequired},
+		reflect.TypeOf(claimsCBOR{}),
+		claimsTagNumber,
+	); err != nil {
+		panic(fmt.Sprintf("CBOR claims tag set initialization failed: %v", err))
+	}
+
+	return tags
+}

--- a/ratsd-token-v2/claims.go
+++ b/ratsd-token-v2/claims.go
@@ -4,9 +4,7 @@ package ratsdtokenv2
 
 import (
 	"fmt"
-	"reflect"
 
-	"github.com/fxamacker/cbor/v2"
 	"github.com/veraison/eat"
 )
 
@@ -49,11 +47,6 @@ type claimsCBOR struct {
 	NonceAdjustFunction *string          `cbor:"-65537,keyasint,omitempty"`
 	NonceAdjustMap      *map[string]uint `cbor:"-65538,keyasint,omitempty"`
 }
-
-var (
-	claimsEncMode = mustClaimsEncMode()
-	claimsDecMode = mustClaimsDecMode()
-)
 
 // SetNonce replaces the stored EAT nonce with the supplied raw nonce value.
 func (c *Claims) SetNonce(v []byte) error {
@@ -354,40 +347,6 @@ func (c claimsCBOR) toClaims() (Claims, error) {
 	}
 
 	return claims, nil
-}
-
-func newClaimsTagSet() cbor.TagSet {
-	tags := cbor.NewTagSet()
-	if err := tags.Add(
-		cbor.TagOptions{EncTag: cbor.EncTagRequired, DecTag: cbor.DecTagRequired},
-		reflect.TypeOf(claimsCBOR{}),
-		claimsTagNumber,
-	); err != nil {
-		panic(fmt.Sprintf("CBOR claims tag set initialization failed: %v", err))
-	}
-
-	return tags
-}
-
-func mustClaimsEncMode() cbor.EncMode {
-	mode, err := cbor.CoreDetEncOptions().EncModeWithTags(newClaimsTagSet())
-	if err != nil {
-		panic(fmt.Sprintf("CBOR claims encoder initialization failed: %v", err))
-	}
-
-	return mode
-}
-
-func mustClaimsDecMode() cbor.DecMode {
-	mode, err := cbor.DecOptions{
-		DupMapKey:         cbor.DupMapKeyEnforcedAPF,
-		ExtraReturnErrors: cbor.ExtraDecErrorUnknownField,
-	}.DecModeWithTags(newClaimsTagSet())
-	if err != nil {
-		panic(fmt.Sprintf("CBOR claims decoder initialization failed: %v", err))
-	}
-
-	return mode
 }
 
 func validateNonce(v []byte) error {

--- a/ratsd-token-v2/evidence.go
+++ b/ratsd-token-v2/evidence.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"math"
 
-	"github.com/fxamacker/cbor/v2"
 	"github.com/veraison/cmw"
 	cose "github.com/veraison/go-cose"
 )
@@ -28,9 +27,6 @@ const (
 )
 
 var (
-	encMode = mustEncMode()
-	decMode = mustDecMode()
-
 	errNilEvidence                = errors.New("nil evidence")
 	errNilClaims                  = errors.New("nil claims")
 	errEmptyOEMID                 = errors.New(`invalid claim "oemid": non-positive value`)
@@ -50,24 +46,6 @@ var (
 	errMissingCollectionType      = errors.New(`missing mandatory CMW collection field "__cmwc_t"`)
 	errMissingRATSDClaimsRecord   = errors.New(`missing mandatory CMW collection field "__ratsd"`)
 )
-
-func mustEncMode() cbor.EncMode {
-	mode, err := cbor.CoreDetEncOptions().EncMode()
-	if err != nil {
-		panic(fmt.Sprintf("CBOR encoder initialization failed: %v", err))
-	}
-
-	return mode
-}
-
-func mustDecMode() cbor.DecMode {
-	mode, err := cbor.DecOptions{}.DecMode()
-	if err != nil {
-		panic(fmt.Sprintf("CBOR decoder initialization failed: %v", err))
-	}
-
-	return mode
-}
 
 // Evidence exposes a RATSD v2 token as the COSE_Sign1 envelope defined in
 // docs/ratsd-token.cddl.


### PR DESCRIPTION
## Summary
- move token v2 CBOR encoder/decoder setup into package init
- keep claims tag-set initialization colocated with CBOR mode setup
- remove eager must* mode globals from claims/evidence files

## Test
- env GOCACHE=/tmp/ratsd-go-build go test -mod=readonly ./ratsd-token-v2