### PR TITLE
Use value receivers for read-only methods

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -165,14 +165,14 @@ func NewServer(logger *zap.SugaredLogger, manager plugin.IManager, options strin
 	}
 }
 
-func (s *Server) reportProblem(w http.ResponseWriter, prob *problems.DefaultProblem) {
+func (s Server) reportProblem(w http.ResponseWriter, prob *problems.DefaultProblem) {
 	s.logger.Error(prob.Detail)
 	w.Header().Set("Content-Type", problems.ProblemMediaType)
 	w.WriteHeader(prob.ProblemStatus())
 	json.NewEncoder(w).Encode(prob)
 }
 
-func (s *Server) RatsdChares(w http.ResponseWriter, r *http.Request, param RatsdCharesParams) {
+func (s Server) RatsdChares(w http.ResponseWriter, r *http.Request, param RatsdCharesParams) {
 	// Check if content type matches the expectation
 	ct := r.Header.Get("Content-Type")
 	if ct != ApplicationvndVeraisonCharesJson {
@@ -500,7 +500,7 @@ func (s *Server) RatsdChares(w http.ResponseWriter, r *http.Request, param Ratsd
 	w.Write(response)
 }
 
-func (s *Server) RatsdSubattesters(w http.ResponseWriter, r *http.Request) {
+func (s Server) RatsdSubattesters(w http.ResponseWriter, r *http.Request) {
 	resp := []SubAttester{}
 
 	pl := s.manager.GetPluginList()

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -82,7 +82,7 @@ type testAttester struct {
 	evidence            []byte
 }
 
-func (t *testAttester) GetEvidence(in *compositor.EvidenceIn) *compositor.EvidenceOut {
+func (t testAttester) GetEvidence(in *compositor.EvidenceIn) *compositor.EvidenceOut {
 	t.t.Helper()
 
 	assert.Equal(t.t, t.expectedContentType, in.ContentType)
@@ -95,18 +95,18 @@ func (t *testAttester) GetEvidence(in *compositor.EvidenceIn) *compositor.Eviden
 	}
 }
 
-func (t *testAttester) GetOptions() *compositor.OptionsOut {
+func (t testAttester) GetOptions() *compositor.OptionsOut {
 	return &compositor.OptionsOut{Status: &compositor.Status{Result: true}}
 }
 
-func (t *testAttester) GetSubAttesterID() *compositor.SubAttesterIDOut {
+func (t testAttester) GetSubAttesterID() *compositor.SubAttesterIDOut {
 	return &compositor.SubAttesterIDOut{
 		Status:        &compositor.Status{Result: true},
 		SubAttesterID: &compositor.SubAttesterID{Name: "test-attester", Version: "1.0.0"},
 	}
 }
 
-func (t *testAttester) GetSupportedFormats() *compositor.SupportedFormatsOut {
+func (t testAttester) GetSupportedFormats() *compositor.SupportedFormatsOut {
 	return &compositor.SupportedFormatsOut{
 		Status:  &compositor.Status{Result: true},
 		Formats: t.formats,

--- a/attesters/mocktsm/mocktsm.go
+++ b/attesters/mocktsm/mocktsm.go
@@ -49,7 +49,7 @@ func getEvidenceError(e error, statusCode uint32) *compositor.EvidenceOut {
 	}
 }
 
-func (m *MockPlugin) GetOptions() *compositor.OptionsOut {
+func (m MockPlugin) GetOptions() *compositor.OptionsOut {
 	options := []*compositor.Option{
 		&compositor.Option{Name: "privilege_level", Type: "string"},
 	}
@@ -61,21 +61,21 @@ func (m *MockPlugin) GetOptions() *compositor.OptionsOut {
 
 }
 
-func (m *MockPlugin) GetSubAttesterID() *compositor.SubAttesterIDOut {
+func (m MockPlugin) GetSubAttesterID() *compositor.SubAttesterIDOut {
 	return &compositor.SubAttesterIDOut{
 		SubAttesterID: sid,
 		Status:        statusSucceeded,
 	}
 }
 
-func (m *MockPlugin) GetSupportedFormats() *compositor.SupportedFormatsOut {
+func (m MockPlugin) GetSupportedFormats() *compositor.SupportedFormatsOut {
 	return &compositor.SupportedFormatsOut{
 		Status:  statusSucceeded,
 		Formats: supportedFormats,
 	}
 }
 
-func (m *MockPlugin) GetEvidence(in *compositor.EvidenceIn) *compositor.EvidenceOut {
+func (m MockPlugin) GetEvidence(in *compositor.EvidenceIn) *compositor.EvidenceOut {
 	if uint32(len(in.Nonce)) != nonceSize {
 		errMsg := fmt.Errorf(
 			"nonce size of the mockTSM attester should be %d, got %d",

--- a/attesters/tsm/tsm.go
+++ b/attesters/tsm/tsm.go
@@ -50,7 +50,7 @@ func getEvidenceError(e error, statusCode uint32) *compositor.EvidenceOut {
 	}
 }
 
-func (t *TSMPlugin) GetOptions() *compositor.OptionsOut {
+func (t TSMPlugin) GetOptions() *compositor.OptionsOut {
 	options := []*compositor.Option{
 		&compositor.Option{Name: "privilege_level", Type: "string"},
 	}
@@ -61,14 +61,14 @@ func (t *TSMPlugin) GetOptions() *compositor.OptionsOut {
 	}
 }
 
-func (t *TSMPlugin) GetSubAttesterID() *compositor.SubAttesterIDOut {
+func (t TSMPlugin) GetSubAttesterID() *compositor.SubAttesterIDOut {
 	return &compositor.SubAttesterIDOut{
 		SubAttesterID: sid,
 		Status:        statusSucceeded,
 	}
 }
 
-func (t *TSMPlugin) GetSupportedFormats() *compositor.SupportedFormatsOut {
+func (t TSMPlugin) GetSupportedFormats() *compositor.SupportedFormatsOut {
 	if _, err := linuxtsm.MakeClient(); err != nil {
 		return &compositor.SupportedFormatsOut{
 			Status: &compositor.Status{
@@ -84,7 +84,7 @@ func (t *TSMPlugin) GetSupportedFormats() *compositor.SupportedFormatsOut {
 	}
 }
 
-func (t *TSMPlugin) GetEvidence(in *compositor.EvidenceIn) *compositor.EvidenceOut {
+func (t TSMPlugin) GetEvidence(in *compositor.EvidenceIn) *compositor.EvidenceOut {
 	if uint32(len(in.Nonce)) != tsmNonceSize {
 		errMsg := fmt.Errorf(
 			"nonce size of the TSM attester should be %d, got %d",

--- a/auth/basic.go
+++ b/auth/basic.go
@@ -74,11 +74,11 @@ func (o *BasicAuthorizer) Init(v *viper.Viper, logger *zap.SugaredLogger) error 
 	return nil
 }
 
-func (o *BasicAuthorizer) Close() error {
+func (o BasicAuthorizer) Close() error {
 	return nil
 }
 
-func (o *BasicAuthorizer) GetMiddleware(next http.Handler) http.Handler {
+func (o BasicAuthorizer) GetMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
 			o.logger.Debugw("auth basic", "path", r.URL.Path)

--- a/auth/passthrough.go
+++ b/auth/passthrough.go
@@ -26,11 +26,11 @@ func (o *PassthroughAuthorizer) Init(v *viper.Viper, logger *zap.SugaredLogger) 
 	return nil
 }
 
-func (o *PassthroughAuthorizer) Close() error {
+func (o PassthroughAuthorizer) Close() error {
 	return nil
 }
 
-func (o *PassthroughAuthorizer) GetMiddleware(next http.Handler) http.Handler {
+func (o PassthroughAuthorizer) GetMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
 			o.logger.Debugw("passthrough", "path", r.URL.Path)

--- a/plugin/goplugin_manager.go
+++ b/plugin/goplugin_manager.go
@@ -53,11 +53,11 @@ func (o *GoPluginManager) Close() error {
 	return nil
 }
 
-func (o *GoPluginManager) LookupByName(name string) (IPluggable, error) {
+func (o GoPluginManager) LookupByName(name string) (IPluggable, error) {
 	return GetGoPluginHandleByNameUsing(o.loader, name)
 }
 
-func (o *GoPluginManager) GetPluginList() []string {
+func (o GoPluginManager) GetPluginList() []string {
 	var registeredPlugin []string
 
 	for name, _ := range o.loader.loadedByName {

--- a/plugin/goplugin_plugin.go
+++ b/plugin/goplugin_plugin.go
@@ -26,12 +26,12 @@ type Plugin struct {
 	Impl IPluggable
 }
 
-func (p *Plugin) GRPCServer(b *plugin.GRPCBroker, s *grpc.Server) error {
+func (p Plugin) GRPCServer(b *plugin.GRPCBroker, s *grpc.Server) error {
 	compositor.RegisterCompositorServer(s, &GRPCServer{Impl: p.Impl})
 	return nil
 }
 
-func (p *Plugin) GRPCClient(ctx context.Context, b *plugin.GRPCBroker, c *grpc.ClientConn) (interface{}, error) {
+func (p Plugin) GRPCClient(ctx context.Context, b *plugin.GRPCBroker, c *grpc.ClientConn) (interface{}, error) {
 	return &GRPCClient{client: compositor.NewCompositorClient(c)}, nil
 }
 

--- a/plugin/goplugin_rpc.go
+++ b/plugin/goplugin_rpc.go
@@ -16,19 +16,19 @@ type GRPCServer struct {
 	Impl IPluggable
 }
 
-func (s *GRPCServer) GetSubAttesterID(ctx context.Context, e *emptypb.Empty) (*compositor.SubAttesterIDOut, error) {
+func (s GRPCServer) GetSubAttesterID(ctx context.Context, e *emptypb.Empty) (*compositor.SubAttesterIDOut, error) {
 	return s.Impl.GetSubAttesterID(), nil
 }
 
-func (s *GRPCServer) GetSupportedFormats(ctx context.Context, e *emptypb.Empty) (*compositor.SupportedFormatsOut, error) {
+func (s GRPCServer) GetSupportedFormats(ctx context.Context, e *emptypb.Empty) (*compositor.SupportedFormatsOut, error) {
 	return s.Impl.GetSupportedFormats(), nil
 }
 
-func (s *GRPCServer) GetEvidence(ctx context.Context, in *compositor.EvidenceIn) (*compositor.EvidenceOut, error) {
+func (s GRPCServer) GetEvidence(ctx context.Context, in *compositor.EvidenceIn) (*compositor.EvidenceOut, error) {
 	return s.Impl.GetEvidence(in), nil
 }
 
-func (s *GRPCServer) GetOptions(ctx context.Context, e *emptypb.Empty) (*compositor.OptionsOut, error) {
+func (s GRPCServer) GetOptions(ctx context.Context, e *emptypb.Empty) (*compositor.OptionsOut, error) {
 	return s.Impl.GetOptions(), nil
 }
 
@@ -36,7 +36,7 @@ type GRPCClient struct {
 	client compositor.CompositorClient
 }
 
-func (c *GRPCClient) GetSubAttesterID() *compositor.SubAttesterIDOut {
+func (c GRPCClient) GetSubAttesterID() *compositor.SubAttesterIDOut {
 	resp, err := c.client.GetSubAttesterID(context.Background(), &emptypb.Empty{})
 	if err != nil {
 		return &compositor.SubAttesterIDOut{
@@ -47,7 +47,7 @@ func (c *GRPCClient) GetSubAttesterID() *compositor.SubAttesterIDOut {
 	return resp
 }
 
-func (c *GRPCClient) GetSupportedFormats() *compositor.SupportedFormatsOut {
+func (c GRPCClient) GetSupportedFormats() *compositor.SupportedFormatsOut {
 	resp, err := c.client.GetSupportedFormats(context.Background(), &emptypb.Empty{})
 	if err != nil {
 		return &compositor.SupportedFormatsOut{
@@ -58,7 +58,7 @@ func (c *GRPCClient) GetSupportedFormats() *compositor.SupportedFormatsOut {
 	return resp
 }
 
-func (c *GRPCClient) GetEvidence(in *compositor.EvidenceIn) *compositor.EvidenceOut {
+func (c GRPCClient) GetEvidence(in *compositor.EvidenceIn) *compositor.EvidenceOut {
 	resp, err := c.client.GetEvidence(context.Background(), in)
 	if err != nil {
 		return &compositor.EvidenceOut{
@@ -69,7 +69,7 @@ func (c *GRPCClient) GetEvidence(in *compositor.EvidenceIn) *compositor.Evidence
 	return resp
 }
 
-func (c *GRPCClient) GetOptions() *compositor.OptionsOut {
+func (c GRPCClient) GetOptions() *compositor.OptionsOut {
 	resp, err := c.client.GetOptions(context.Background(), &emptypb.Empty{})
 	if err != nil {
 		return &compositor.OptionsOut{

--- a/tokens/tsm-report.go
+++ b/tokens/tsm-report.go
@@ -52,7 +52,7 @@ type TSMReport struct {
 }
 
 // Valid checks if the TSMReport is populated correctly
-func (t *TSMReport) Valid() error {
+func (t TSMReport) Valid() error {
 	if len(t.OutBlob) == 0 {
 		return errors.New(`missing mandatory field "outblob"`)
 	}
@@ -69,7 +69,7 @@ func (t *TSMReport) Valid() error {
 }
 
 // ToJSON encodes TSMReport as JSON
-func (t *TSMReport) ToJSON() ([]byte, error) {
+func (t TSMReport) ToJSON() ([]byte, error) {
 	if err := t.Valid(); err != nil {
 		return nil, fmt.Errorf("JSON encoding failed: %w", err)
 	}
@@ -91,7 +91,7 @@ func (t *TSMReport) FromJSON(data []byte) error {
 }
 
 // ToCBOR encodes TSMReport as CBOR
-func (t *TSMReport) ToCBOR() ([]byte, error) {
+func (t TSMReport) ToCBOR() ([]byte, error) {
 	if err := t.Valid(); err != nil {
 		return nil, fmt.Errorf("CBOR encoding failed: %w", err)
 	}


### PR DESCRIPTION
## Summary
- convert read-only plugin, token, API, and authorizer methods to value receivers
- retain pointer receivers for mutating and nil-sensitive methods

## Testing
- go test ./auth ./plugin

Signed-off-by: Ian Chin Wang <ian.chin.wang@oracle.com>