### PR TITLE
ci: upgrade Go version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.24.0'
+        go-version: '1.25.0'
 
     - name: Install Protoc
       uses: arduino/setup-protoc@v3


### PR DESCRIPTION
## Summary
- update the GitHub Actions Go toolchain from 1.24.0 to 1.25.0
- align CI with the Go version declared in go.mod

## Testing
- git diff --check